### PR TITLE
fix(tsf): JIS 配列の半角/全角キーで ime_toggle が効くようにする

### DIFF
--- a/crates/rakukan-tsf/src/engine/keymap.rs
+++ b/crates/rakukan-tsf/src/engine/keymap.rs
@@ -155,7 +155,9 @@ fn name_to_vk(name: &str) -> Option<u16> {
         "f10" => 0x79,
         "f11" => 0x7A,
         "f12" => 0x7B,
-        "zenkaku" | "hankaku" | "kanji" => 0x19, // VK_KANJI (全角/半角キー)
+        // 全角/半角キー。JIS 配列の実際の VK は 0xF3 / 0xF4 だが、
+        // normalize_key_event_vk() が 0x19 に寄せてから resolve_action へ渡す。
+        "zenkaku" | "hankaku" | "kanji" => 0x19, // VK_KANJI
         "henkan" => 0x1C,
         "muhenkan" => 0x1D,
         "eisuu" | "alphanumeric" => 0xF0, // 英数キー

--- a/crates/rakukan-tsf/src/tsf/factory.rs
+++ b/crates/rakukan-tsf/src/tsf/factory.rs
@@ -892,6 +892,15 @@ fn normalize_key_event_vk(vk: u16) -> u16 {
     if vk == 0x27 && ctrl && alt && !shift && space_down {
         return 0x20;
     }
+
+    // JIS 配列の半角/全角キーは VK_KANJI ではなく VK_DBE_SBCSCHAR (0xF3) /
+    // VK_DBE_DBCSCHAR (0xF4) を送る（現在の IME 状態でどちらになるかが変わる）。
+    // VK_KANJI (0x19) が来るのは Alt 併用の「漢字」キーとしての用法のときだけ。
+    // keymap 側は "Zenkaku" = 0x19 で持っているので、ここで 0x19 に寄せる。
+    if vk == 0xF3 || vk == 0xF4 {
+        return 0x19;
+    }
+
     vk
 }
 


### PR DESCRIPTION
#1 の修正です。

## 問題

JIS 配列キーボードでは、半角/全角キー (scancode `0x29`) が送出する仮想キーコードは
**`VK_DBE_SBCSCHAR` (0xF3) / `VK_DBE_DBCSCHAR` (0xF4)** であり、`VK_KANJI` (0x19) ではありません。
`0x19` が来るのは Alt 併用の「漢字」キーとしての用法のときだけです。

```
MapVirtualKeyEx(0x29, MAPVK_VSC_TO_VK_EX, 0x04110411)  ->  0xF3   (日本語配列)
MapVirtualKeyEx(0x29, MAPVK_VSC_TO_VK_EX, 0x04090409)  ->  0xC0   (参考: US 配列)
```

このため `keymap.toml` の既定 `key = "Zenkaku"` / `action = "ime_toggle"` が動作しません。
`name_to_vk()` に数値指定の経路が無いので、ユーザー側で `keymap.toml` を編集して回避することもできません。

## 修正方針

両方のキー入口 (`OnTestKeyDown` / `OnKeyDown`) が既に `normalize_key_event_vk()` を
通っているので、そこで `0xF3` / `0xF4` を `0x19` に正規化しました。

keymap 側の表現 (`"Zenkaku"` = `0x19`) を変えずに済むため、既存の設定ファイルとの
互換性が保たれ、`name_to_vk()` にも手を入れずに済みます。

あわせて `keymap.rs` の該当行に、実際の VK と正規化の関係をコメントとして残しました。

## 動作確認

- Windows 11 Pro 10.0.26200 / 日本語配列キーボード (kbd106.dll, HKL 0x04110411)
- 修正前: 半角/全角キーで切り替わらない (Ctrl+Space は動作する)
- 修正後: 半角/全角キーで切り替わる。Ctrl+Space も従来どおり動作
- `cargo check -p rakukan-tsf --release` 通過 (警告なし)

US 配列環境は手元に無いため未確認ですが、`0xF3`/`0xF4` は US 配列では発生しないため
影響は無いと考えています。