### PR TITLE
fix(engine): 数字の直後の数詞を漢数字単位として変換する（5まん → 5万）

### DIFF
--- a/crates/rakukan-engine/src/digits.rs
+++ b/crates/rakukan-engine/src/digits.rs
@@ -920,30 +920,31 @@ pub fn convert_with_digit_protection(
             // ここで作ると「一十」「壱十」のような候補まで生成してしまう。
             // 組み合わせは combine_runs が第 1 表記から順に作るので、先頭に来るのは
             // 「1十」であって「一十」ではない。
-            if i > 0 && runs[i - 1].is_digit() {
-                if let Some((unit, promote)) = numeric_unit_kanji(s) {
-                    cands.retain(|c| c != unit);
-                    // promote=false（同音異義語あり）は変換器の第 1 候補を既定のまま
-                    // 残し、数詞はその次に置く。候補として存在させることだけを保証する。
-                    //
-                    // ただし単純に 1 番目へ入れると、変換器の第 1 候補が数字だけの
-                    // 表記だったときに数詞が先頭へ繰り上がってしまう。「じゅう」は
-                    // 変換器が「10」を第 1 候補に返すが、これは数字保存の検証で
-                    // 落ちるため（入力の数字は「1」だけ）、結果として「1十」が
-                    // 先頭に立つ。落ちると分かっている候補は数えず、実際に残る
-                    // 最初の候補の後ろへ置く。
-                    let at = if promote {
-                        0
-                    } else {
-                        cands
-                            .iter()
-                            .position(|c| !is_numeric_text(c))
-                            .map(|p| p + 1)
-                            .unwrap_or(0)
-                            .min(cands.len())
-                    };
-                    cands.insert(at, unit.to_string());
-                }
+            if i > 0
+                && runs[i - 1].is_digit()
+                && let Some((unit, promote)) = numeric_unit_kanji(s)
+            {
+                cands.retain(|c| c != unit);
+                // promote=false（同音異義語あり）は変換器の第 1 候補を既定のまま
+                // 残し、数詞はその次に置く。候補として存在させることだけを保証する。
+                //
+                // ただし単純に 1 番目へ入れると、変換器の第 1 候補が数字だけの
+                // 表記だったときに数詞が先頭へ繰り上がってしまう。「じゅう」は
+                // 変換器が「10」を第 1 候補に返すが、これは数字保存の検証で
+                // 落ちるため（入力の数字は「1」だけ）、結果として「1十」が
+                // 先頭に立つ。落ちると分かっている候補は数えず、実際に残る
+                // 最初の候補の後ろへ置く。
+                let at = if promote {
+                    0
+                } else {
+                    cands
+                        .iter()
+                        .position(|c| !is_numeric_text(c))
+                        .map(|p| p + 1)
+                        .unwrap_or(0)
+                        .min(cands.len())
+                };
+                cands.insert(at, unit.to_string());
             }
             run_candidates.push(cands);
         }

--- a/crates/rakukan-engine/src/digits.rs
+++ b/crates/rakukan-engine/src/digits.rs
@@ -720,15 +720,53 @@ fn make_run(kind: CharKind, text: String) -> Run {
     }
 }
 
+/// 数字だけで構成された文字列か（算用数字・全角数字・漢数字）。
+///
+/// かな run の候補が数そのものになっていることがある（「じゅう」→「10」）。
+/// こうした候補は、入力側の数字と一致しないかぎり数字保存の検証で落ちる。
+fn is_numeric_text(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_digit() || ('０'..='９').contains(&c) || is_kanji_number_char(c))
+}
+
+/// 位取りの単位（十・百・千・万・億・兆・京）だけで構成された漢字 run か。
+///
+/// 「万」「千万」のように単位だけの run は、それ自体では数を表さない。
+/// 数字の直後に現れた場合は「その数字に付いた単位」であって、独立した
+/// 数値ではない（`5万` の `万` は 10000 という別の数ではない）。
+fn is_unit_only_kanji_run(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| small_kanji_unit(c).is_some() || large_kanji_unit(c).is_some())
+}
+
+/// 入力・出力から「含まれる数」を数字列として取り出す。
+///
+/// 漢数字は算用数字へ正規化して比較できるようにする（`二〇二四` → `2024`）。
+///
+/// ただし **数字 run の直後に単位だけの漢字 run が続く場合、その単位は数値として
+/// 数えない**。`5まん` → `5万` を検証するとき、素朴に数えると入力の `5` に対して
+/// 出力が `5` + `10000` になり、数字が改変されたと誤判定して正しい候補を捨てて
+/// しまうため。`5万円`・`5万5千`・`10万以上` のように単位のあとに語が続く場合も
+/// 同じ。
+///
+/// 数字に隣接していない漢数字 run は従来どおり数値として解釈する。
+/// `2024ねん` → `二千二十四年` が `2024` に正規化されて一致する挙動は変わらない。
 fn extract_digits(s: &str) -> String {
     let mut out = String::new();
     let mut kanji_run = String::new();
+    // 直前に出力した文字が数字だったか（漢字 run が数字に隣接しているかの判定用）
+    let mut after_digit = false;
 
-    let flush_kanji_run = |out: &mut String, kanji_run: &mut String| {
+    let flush_kanji_run = |out: &mut String, kanji_run: &mut String, after_digit: bool| {
         if kanji_run.is_empty() {
             return;
         }
-        if let Some(digits) = parse_kanji_number_digits(kanji_run) {
+        // 数字の直後の「万」「千」などは、その数字に付いた単位として読み飛ばす
+        if !(after_digit && is_unit_only_kanji_run(kanji_run))
+            && let Some(digits) = parse_kanji_number_digits(kanji_run)
+        {
             out.push_str(&digits);
         }
         kanji_run.clear();
@@ -736,18 +774,21 @@ fn extract_digits(s: &str) -> String {
 
     for c in s.chars() {
         if c.is_ascii_digit() {
-            flush_kanji_run(&mut out, &mut kanji_run);
+            flush_kanji_run(&mut out, &mut kanji_run, after_digit);
             out.push(c);
+            after_digit = true;
         } else if ('０'..='９').contains(&c) {
-            flush_kanji_run(&mut out, &mut kanji_run);
+            flush_kanji_run(&mut out, &mut kanji_run, after_digit);
             out.push(char::from_u32(c as u32 - '０' as u32 + '0' as u32).unwrap_or(c));
+            after_digit = true;
         } else if is_kanji_number_char(c) {
             kanji_run.push(c);
         } else {
-            flush_kanji_run(&mut out, &mut kanji_run);
+            flush_kanji_run(&mut out, &mut kanji_run, after_digit);
+            after_digit = false;
         }
     }
-    flush_kanji_run(&mut out, &mut kanji_run);
+    flush_kanji_run(&mut out, &mut kanji_run, after_digit);
     out
 }
 
@@ -771,29 +812,41 @@ pub fn verify_digits_preserved(input: &str, output: &str) -> bool {
 /// 構造的に候補へ出てこないことだけを補い、どれを既定にするかは文脈を見た
 /// 変換器に任せる、という切り分け。
 ///
-/// なお、このルールが発動するのは run が `[Digit, Kana]` の 2 つで、かつ
-/// かな run が数詞に完全一致する場合だけ。「5せんのしはらい」は かな run が
-/// `"せんのしはらい"` になるため対象外で、文脈ごと LLM が変換する。
-/// つまりここで扱うのは実質「文脈が存在しない単独入力」に限られる。
+/// このルールが発動するのは、**直前の run が数字 run** で、かつ かな run が
+/// 数詞に完全一致する場合だけ。`5まん` のほか `だい5まん`・`3.5まん` のように
+/// 前に別の run があっても効く。「5せんのしはらい」は かな run が
+/// `"せんのしはらい"` になるため対象外で、文脈ごと変換器が扱う。
 ///
 /// 完全一致のみを見るのは前方一致による破壊を避けるため。前方一致にすると
 /// 「3まんが」のような読みを「3万が」に固定してしまう。
 ///
-/// なお、この救済候補を run の候補リストに差し込んで `combine_runs` に通すのは
-/// 誤り。`verify_digits_preserved` が「万」を数値 10000 と読むため
-/// 「5万」が数字改変とみなされて捨てられ、生成順の都合で候補が全滅しうる。
-/// 呼び出し側は verify の後に直接差し込むこと。
+/// この候補は かな run の候補リストへ足して `combine_runs` に通す。以前は
+/// `verify_digits_preserved` が「万」を数値 10000 と読んで「5万」を数字改変と
+/// みなすため、フィルタを迂回して後から差し込む必要があったが、
+/// `extract_digits()` が数字直後の単位を独立した数値として数えなくなったので
+/// その回避は不要になった。
 fn numeric_unit_kanji(reading: &str) -> Option<(&'static str, bool)> {
-    match reading {
-        "まん" => Some(("万", true)),
-        "おく" => Some(("億", true)),
-        "ちょう" => Some(("兆", false)),
-        "せん" => Some(("千", false)),
-        "ひゃく" => Some(("百", false)),
-        "じゅう" => Some(("十", false)),
-        _ => None,
-    }
+    NUMERIC_UNITS
+        .iter()
+        .find(|(r, _, _)| *r == reading)
+        .map(|(_, kanji, promote)| (*kanji, *promote))
 }
+
+/// (読み, 漢数詞, 第 1 候補に置いてよいか)
+///
+/// 連濁形（`3ぜん` = 3千、`3びゃく` / `3ぴゃく` = 3百）も入れる。数字の直後に
+/// 現れるこれらは数詞以外に読みようが無いが、同音語の有無は清音形に合わせる。
+const NUMERIC_UNITS: [(&str, &str, bool); 9] = [
+    ("まん", "万", true),
+    ("おく", "億", true),
+    ("ちょう", "兆", false),
+    ("せん", "千", false),
+    ("ぜん", "千", false),
+    ("ひゃく", "百", false),
+    ("びゃく", "百", false),
+    ("ぴゃく", "百", false),
+    ("じゅう", "十", false),
+];
 
 fn build_local_context(runs: &[Run], kana_index: usize, global_context: &str) -> String {
     let mut ctx = String::from(global_context);
@@ -855,7 +908,43 @@ pub fn convert_with_digit_protection(
             ));
         } else if let Run::Kana(s) = run {
             let local_context = build_local_context(&runs, i, context);
-            let cands = converter.convert(s, &local_context, num_candidates)?;
+            let mut cands = converter.convert(s, &local_context, num_candidates)?;
+            // 数字 run の直後のかな run が数詞そのものなら、漢数詞を候補に足す。
+            //
+            // かな run は数字 run と切り離して変換器へ渡るため、「まん」単独では
+            // 数詞と判断する手掛かりが無く「満」「マン」しか返らない。構造的に
+            // 候補へ出てこない分だけをここで補い、数字表記との組み合わせ・重複
+            // 排除・件数制限は combine_runs 以降の通常の経路に任せる。
+            //
+            // 足すのは単位の漢字 1 つだけ。数字表記（1/１/一/壱…）との総当たりを
+            // ここで作ると「一十」「壱十」のような候補まで生成してしまう。
+            // 組み合わせは combine_runs が第 1 表記から順に作るので、先頭に来るのは
+            // 「1十」であって「一十」ではない。
+            if i > 0 && runs[i - 1].is_digit() {
+                if let Some((unit, promote)) = numeric_unit_kanji(s) {
+                    cands.retain(|c| c != unit);
+                    // promote=false（同音異義語あり）は変換器の第 1 候補を既定のまま
+                    // 残し、数詞はその次に置く。候補として存在させることだけを保証する。
+                    //
+                    // ただし単純に 1 番目へ入れると、変換器の第 1 候補が数字だけの
+                    // 表記だったときに数詞が先頭へ繰り上がってしまう。「じゅう」は
+                    // 変換器が「10」を第 1 候補に返すが、これは数字保存の検証で
+                    // 落ちるため（入力の数字は「1」だけ）、結果として「1十」が
+                    // 先頭に立つ。落ちると分かっている候補は数えず、実際に残る
+                    // 最初の候補の後ろへ置く。
+                    let at = if promote {
+                        0
+                    } else {
+                        cands
+                            .iter()
+                            .position(|c| !is_numeric_text(c))
+                            .map(|p| p + 1)
+                            .unwrap_or(0)
+                            .min(cands.len())
+                    };
+                    cands.insert(at, unit.to_string());
+                }
+            }
             run_candidates.push(cands);
         }
     }
@@ -867,30 +956,15 @@ pub fn convert_with_digit_protection(
         .filter(|c| verify_digits_preserved(reading, c))
         .collect();
 
-    // 「5まん」→「5万」の救済。
-    //
-    // この候補は verify_digits_preserved を意図的に通していない。extract_digits() は
-    // 「万」を数値 10000 として読むため、入力「5まん」の数字 "5" と出力「5万」の
-    // "5"+"10000" が一致せず、数字が改変されたと誤判定されて捨てられてしまう。
-    // ここは数字 run と数詞をこちらで組み立てており、数字が保存されていることは
-    // 自明なので、フィルタの後に直接差し込む。
-    // 数字表記は digit_candidates_order の設定に従う。生の run テキストを
-    // そのまま使うと、arabic を除外している設定でも半角数字が先頭に出てしまう。
-    if let [Run::Digit(d), Run::Kana(k)] = runs.as_slice() {
-        if let Some((unit, promote)) = numeric_unit_kanji(k) {
-            // promote=false（同音異義語あり）は LLM の第 1 候補を既定のまま残し、
-            // 数詞はその次に置く。候補として存在させることだけを保証する。
-            let at = if promote { 0 } else { 1.min(verified.len()) };
-            for digit in digit_candidates(d, digit_candidates_order)
-                .into_iter()
-                .rev()
-            {
-                let cand = format!("{digit}{unit}");
-                verified.retain(|c| c != &cand);
-                verified.insert(at.min(verified.len()), cand);
-            }
-        }
-    }
+    // 数詞（「5まん」→「5万」）の救済は、かな run の候補へ漢数詞を足す形で
+    // 上の run ループが行う。`extract_digits()` が数字直後の単位を独立した
+    // 数値として数えなくなったため、この経路の候補も verify を素通りできる。
+    // フィルタを迂回して後から差し込む必要は無くなった。
+
+    // 重複排除と件数制限を最後に通す。
+    let mut seen = std::collections::HashSet::new();
+    verified.retain(|c| seen.insert(c.clone()));
+    verified.truncate(num_candidates);
 
     if verified.is_empty() {
         Ok(vec![reading.to_string()])
@@ -1325,12 +1399,115 @@ mod tests {
     }
 
     #[test]
-    fn digit_plus_unit_is_rejected_by_digit_verification() {
-        // 「5万」は verify_digits_preserved を通らない（万が 10000 と読まれる）。
-        // この性質があるため、救済候補は verify の後に差し込む必要がある。
-        assert!(!verify_digits_preserved("5まん", "5万"));
-        // 一方、単位を伴わない通常の候補は通る
+    fn digit_followed_by_unit_kanji_passes_verification() {
+        // 数字の直後の「万」は、その数字に付いた単位であって独立した 10000 では
+        // ない。以前はここで 10000 を加算してしまい、正しい候補を数字改変として
+        // 捨てていた。
+        assert!(verify_digits_preserved("5まん", "5万"));
+        assert!(verify_digits_preserved("5まんえん", "5万円"));
+        assert!(verify_digits_preserved("だい5まん", "第5万"));
+        assert!(verify_digits_preserved("3.5まん", "3.5万"));
+        assert!(verify_digits_preserved("3ぜん", "3千"));
+        assert!(verify_digits_preserved("1じゅう", "1十"));
+        assert!(verify_digits_preserved("5まん5せん", "5万5千"));
+        assert!(verify_digits_preserved("10まんいじょう", "10万以上"));
+        // 単位を伴わない通常の候補も従来どおり通る
         assert!(verify_digits_preserved("5まん", "5マン"));
+    }
+
+    #[test]
+    fn digit_tampering_is_still_rejected_around_units() {
+        // 単位を読み飛ばすようにしても、数字そのものの改変は捕まえる
+        assert!(!verify_digits_preserved("5まん", "50万"));
+        assert!(!verify_digits_preserved("5まん", "6万"));
+        assert!(!verify_digits_preserved("5まんえん", "5万5円"));
+
+        // 既知の限界: `extract_digits()` は小数点を拾わないので、`3.5` と `35` は
+        // 区別できない。この検証は「数字の並びが保存されているか」だけを見る。
+        // 単位の読み飛ばしとは独立した以前からの性質。
+        assert!(verify_digits_preserved("3.5まん", "35万"));
+    }
+
+    #[test]
+    fn kanji_number_not_adjacent_to_digit_is_still_a_number() {
+        // 数字に隣接していない漢数字 run は従来どおり数値として解釈する。
+        // 既存の数値表現変換（2024ねん → 二千二十四年）を壊さないこと。
+        assert!(verify_digits_preserved("2024ねん", "二千二十四年"));
+        assert!(verify_digits_preserved("2024ねん", "2024年"));
+        assert!(!verify_digits_preserved("2024ねん", "二千二十五年"));
+        // 単位だけの run でも、数字に続いていなければ数値として読む
+        assert!(!verify_digits_preserved("まん", "5万"));
+    }
+
+    #[test]
+    fn numeric_units_cover_rendaku_forms() {
+        assert_eq!(numeric_unit_kanji("ぜん").map(|(k, _)| k), Some("千"));
+        assert_eq!(numeric_unit_kanji("びゃく").map(|(k, _)| k), Some("百"));
+        assert_eq!(numeric_unit_kanji("ぴゃく").map(|(k, _)| k), Some("百"));
+        // 第 1 候補に置いてよいのは同音異義語の無い「万」「億」だけ
+        assert_eq!(numeric_unit_kanji("まん").map(|(_, p)| p), Some(true));
+        assert_eq!(numeric_unit_kanji("おく").map(|(_, p)| p), Some(true));
+        assert_eq!(numeric_unit_kanji("せん").map(|(_, p)| p), Some(false));
+        assert_eq!(numeric_unit_kanji("じゅう").map(|(_, p)| p), Some(false));
+        // 数詞でない読みは拾わない
+        assert_eq!(numeric_unit_kanji("まい"), None);
+        assert_eq!(numeric_unit_kanji("まんが"), None);
+    }
+
+    #[test]
+    fn unit_only_kanji_run_detection() {
+        assert!(is_unit_only_kanji_run("万"));
+        assert!(is_unit_only_kanji_run("千"));
+        assert!(is_unit_only_kanji_run("千万"));
+        // 数字を含む run は「単位だけ」ではない
+        assert!(!is_unit_only_kanji_run("二千"));
+        assert!(!is_unit_only_kanji_run("五"));
+        assert!(!is_unit_only_kanji_run(""));
+    }
+
+    #[test]
+    fn numeric_text_detection() {
+        assert!(is_numeric_text("10"));
+        assert!(is_numeric_text("１０"));
+        assert!(is_numeric_text("十"));
+        assert!(is_numeric_text("二千"));
+        assert!(!is_numeric_text("重"));
+        assert!(!is_numeric_text("10円"));
+        assert!(!is_numeric_text(""));
+    }
+
+    /// 数字直後の数詞を実モデルで確認する診断用プローブ。
+    ///
+    /// `convert_with_digit_protection()` は変換器を通るため純粋なユニットテストでは
+    /// 押さえられない。受入条件の読みを実際に流し、候補に何が並ぶかを目で見るための
+    /// もの。モデルのロードが入るので既定では走らせない。
+    ///
+    /// 実行: `cargo test -p rakukan-engine --lib probe_numeric_unit_candidates -- --ignored --nocapture`
+    #[test]
+    #[ignore = "実モデルのロードが必要"]
+    fn probe_numeric_unit_candidates() {
+        use crate::kanji::Backend;
+
+        let backend =
+            Backend::from_variant_id("jinen-v1-small-q5").expect("Failed to load default model");
+        let converter = KanaKanjiConverter::new(backend).expect("Failed to create converter");
+        let order = default_digit_candidates_order();
+
+        for reading in [
+            "5まん",
+            "5まんえん",
+            "だい5まん",
+            "3.5まん",
+            "3ぜん",
+            "1じゅう",
+            "10まん",
+            "3せん",
+        ] {
+            let cands =
+                convert_with_digit_protection(&converter, reading, "", 9, &order, false, false)
+                    .unwrap_or_else(|e| panic!("{reading}: {e:?}"));
+            println!("{reading:>12} -> {cands:?}");
+        }
     }
 
     #[test]
@@ -1341,7 +1518,6 @@ mod tests {
         assert_eq!(runs[0].text(), "5");
         assert_eq!(runs[1].text(), "まん");
     }
-    #[test]
     #[test]
     fn numeric_unit_promotion_depends_on_ambiguity() {
         // 数字の直後でほぼ一意 → 第 1 候補に置いてよい

--- a/crates/rakukan-engine/src/digits.rs
+++ b/crates/rakukan-engine/src/digits.rs
@@ -741,19 +741,45 @@ fn is_unit_only_kanji_run(s: &str) -> bool {
             .all(|c| small_kanji_unit(c).is_some() || large_kanji_unit(c).is_some())
 }
 
+/// 数字直後の単位漢字 run `units` の読み飛ばしを、入力読み `reading` が正当化するか。
+///
+/// run 内のすべての単位について、対応する数詞かな（まん/せん/ぜん…）が入力読みに
+/// 含まれている場合のみ true。この条件が無いと、単位を無条件に読み飛ばすことになり、
+/// 「5えん」→「5万円」のように変換器が単位を勝手に挿入した候補（数を 1 万倍に変える
+/// 改変）を数字保存の検証で見逃してしまう。
+///
+/// 大字は単位の値で照合する（「拾」は「じゅう」で正当化される）。
+/// `NUMERIC_UNITS` に読みが無い「京」は正当化されず、従来どおり数値として数える。
+fn reading_licenses_units(reading: &str, units: &str) -> bool {
+    let unit_value = |c: char| small_kanji_unit(c).or_else(|| large_kanji_unit(c));
+    units.chars().all(|u| {
+        let Some(val) = unit_value(u) else {
+            return false;
+        };
+        NUMERIC_UNITS.iter().any(|(r, kanji, _)| {
+            kanji.chars().next().and_then(unit_value) == Some(val) && reading.contains(r)
+        })
+    })
+}
+
 /// 入力・出力から「含まれる数」を数字列として取り出す。
 ///
 /// 漢数字は算用数字へ正規化して比較できるようにする（`二〇二四` → `2024`）。
 ///
-/// ただし **数字 run の直後に単位だけの漢字 run が続く場合、その単位は数値として
-/// 数えない**。`5まん` → `5万` を検証するとき、素朴に数えると入力の `5` に対して
+/// ただし **数字 run の直後に単位だけの漢字 run が続き、かつ入力読み `reading` に
+/// 対応する数詞かなが含まれる場合、その単位は数値として数えない**。
+/// `5まん` → `5万` を検証するとき、素朴に数えると入力の `5` に対して
 /// 出力が `5` + `10000` になり、数字が改変されたと誤判定して正しい候補を捨てて
 /// しまうため。`5万円`・`5万5千`・`10万以上` のように単位のあとに語が続く場合も
 /// 同じ。
 ///
+/// 読み飛ばしを入力読み側の数詞かなで正当化するのは、無条件に読み飛ばすと
+/// 「5えん」→「5万円」のような単位の挿入（数の改変）まで通してしまうため
+/// （`reading_licenses_units` を参照）。
+///
 /// 数字に隣接していない漢数字 run は従来どおり数値として解釈する。
 /// `2024ねん` → `二千二十四年` が `2024` に正規化されて一致する挙動は変わらない。
-fn extract_digits(s: &str) -> String {
+fn extract_digits(s: &str, reading: &str) -> String {
     let mut out = String::new();
     let mut kanji_run = String::new();
     // 直前に出力した文字が数字だったか（漢字 run が数字に隣接しているかの判定用）
@@ -763,8 +789,11 @@ fn extract_digits(s: &str) -> String {
         if kanji_run.is_empty() {
             return;
         }
-        // 数字の直後の「万」「千」などは、その数字に付いた単位として読み飛ばす
-        if !(after_digit && is_unit_only_kanji_run(kanji_run))
+        // 数字の直後の「万」「千」などは、入力読みに対応する数詞かなが
+        // ある場合に限り、その数字に付いた単位として読み飛ばす
+        if !(after_digit
+            && is_unit_only_kanji_run(kanji_run)
+            && reading_licenses_units(reading, kanji_run))
             && let Some(digits) = parse_kanji_number_digits(kanji_run)
         {
             out.push_str(&digits);
@@ -793,7 +822,9 @@ fn extract_digits(s: &str) -> String {
 }
 
 pub fn verify_digits_preserved(input: &str, output: &str) -> bool {
-    extract_digits(input) == extract_digits(output)
+    // 単位の読み飛ばしは、入力読み（かな）に対応する数詞があるときだけ許す。
+    // どちら側の抽出にも同じ入力読みを渡す。
+    extract_digits(input, input) == extract_digits(output, input)
 }
 
 /// 数字 run の直後に単独で現れたとき、数詞（位取りの単位）として解釈すべき読み。
@@ -1412,6 +1443,8 @@ mod tests {
         assert!(verify_digits_preserved("1じゅう", "1十"));
         assert!(verify_digits_preserved("5まん5せん", "5万5千"));
         assert!(verify_digits_preserved("10まんいじょう", "10万以上"));
+        // 大字は単位の値で照合する（拾 = 十）
+        assert!(verify_digits_preserved("5じゅう", "5拾"));
         // 単位を伴わない通常の候補も従来どおり通る
         assert!(verify_digits_preserved("5まん", "5マン"));
     }
@@ -1422,6 +1455,15 @@ mod tests {
         assert!(!verify_digits_preserved("5まん", "50万"));
         assert!(!verify_digits_preserved("5まん", "6万"));
         assert!(!verify_digits_preserved("5まんえん", "5万5円"));
+
+        // 単位の「挿入」も改変として捕まえる。読み飛ばしてよいのは、入力読みに
+        // 対応する数詞かなが含まれる場合だけ。5えん → 5万円 は数を 1 万倍に
+        // 変える改変であり、通してはいけない。
+        assert!(!verify_digits_preserved("5えん", "5万円"));
+        assert!(!verify_digits_preserved("5", "5万"));
+        // 照合は単位ごと。「おく」が正当化するのは 億 だけで、万 は通さない
+        assert!(!verify_digits_preserved("5おく", "5万"));
+        assert!(!verify_digits_preserved("5まん", "5億"));
 
         // 既知の限界: `extract_digits()` は小数点を拾わないので、`3.5` と `35` は
         // 区別できない。この検証は「数字の並びが保存されているか」だけを見る。

--- a/crates/rakukan-engine/src/digits.rs
+++ b/crates/rakukan-engine/src/digits.rs
@@ -763,21 +763,34 @@ pub fn verify_digits_preserved(input: &str, output: &str) -> bool {
 /// 「5まん」が「5満」「5マン」になる。数字の直後という限定した条件でのみ、
 /// 数詞の漢字を先頭に差し込んで救済する。
 ///
-/// 完全一致のみを対象にしているのは誤爆を避けるため。前方一致にすると
-/// 「3せんち」(3センチ) が「3千ち」になるなど、実在する読みを壊す。
+/// 戻り値の `bool` は「第 1 候補に置いてよいか」。
+///
+/// `true` は数字の直後という条件下でほぼ一意な単位。`false` は同音異義語が
+/// あるもので、候補には入れるが順位は LLM の判断に譲る
+/// （「3せん」= 3戦/3選、「1ちょう」= 1丁、「5じゅう」= 5重 など）。
+/// 構造的に候補へ出てこないことだけを補い、どれを既定にするかは文脈を見た
+/// 変換器に任せる、という切り分け。
+///
+/// なお、このルールが発動するのは run が `[Digit, Kana]` の 2 つで、かつ
+/// かな run が数詞に完全一致する場合だけ。「5せんのしはらい」は かな run が
+/// `"せんのしはらい"` になるため対象外で、文脈ごと LLM が変換する。
+/// つまりここで扱うのは実質「文脈が存在しない単独入力」に限られる。
+///
+/// 完全一致のみを見るのは前方一致による破壊を避けるため。前方一致にすると
+/// 「3まんが」のような読みを「3万が」に固定してしまう。
 ///
 /// なお、この救済候補を run の候補リストに差し込んで `combine_runs` に通すのは
 /// 誤り。`verify_digits_preserved` が「万」を数値 10000 と読むため
 /// 「5万」が数字改変とみなされて捨てられ、生成順の都合で候補が全滅しうる。
 /// 呼び出し側は verify の後に直接差し込むこと。
-fn numeric_unit_kanji(reading: &str) -> Option<&'static str> {
+fn numeric_unit_kanji(reading: &str) -> Option<(&'static str, bool)> {
     match reading {
-        "じゅう" => Some("十"),
-        "ひゃく" => Some("百"),
-        "せん" => Some("千"),
-        "まん" => Some("万"),
-        "おく" => Some("億"),
-        "ちょう" => Some("兆"),
+        "まん" => Some(("万", true)),
+        "おく" => Some(("億", true)),
+        "ちょう" => Some(("兆", false)),
+        "せん" => Some(("千", false)),
+        "ひゃく" => Some(("百", false)),
+        "じゅう" => Some(("十", false)),
         _ => None,
     }
 }
@@ -861,11 +874,21 @@ pub fn convert_with_digit_protection(
     // "5"+"10000" が一致せず、数字が改変されたと誤判定されて捨てられてしまう。
     // ここは数字 run と数詞をこちらで組み立てており、数字が保存されていることは
     // 自明なので、フィルタの後に直接差し込む。
+    // 数字表記は digit_candidates_order の設定に従う。生の run テキストを
+    // そのまま使うと、arabic を除外している設定でも半角数字が先頭に出てしまう。
     if let [Run::Digit(d), Run::Kana(k)] = runs.as_slice() {
-        if let Some(unit) = numeric_unit_kanji(k) {
-            let cand = format!("{d}{unit}");
-            verified.retain(|c| c != &cand);
-            verified.insert(0, cand);
+        if let Some((unit, promote)) = numeric_unit_kanji(k) {
+            // promote=false（同音異義語あり）は LLM の第 1 候補を既定のまま残し、
+            // 数詞はその次に置く。候補として存在させることだけを保証する。
+            let at = if promote { 0 } else { 1.min(verified.len()) };
+            for digit in digit_candidates(d, digit_candidates_order)
+                .into_iter()
+                .rev()
+            {
+                let cand = format!("{digit}{unit}");
+                verified.retain(|c| c != &cand);
+                verified.insert(at.min(verified.len()), cand);
+            }
         }
     }
 
@@ -1302,17 +1325,6 @@ mod tests {
     }
 
     #[test]
-    fn numeric_unit_after_digit_is_recognized() {
-        assert_eq!(numeric_unit_kanji("まん"), Some("万"));
-        assert_eq!(numeric_unit_kanji("おく"), Some("億"));
-        assert_eq!(numeric_unit_kanji("せん"), Some("千"));
-        // 前方一致にすると「3せんち」を壊すので、完全一致のみ
-        assert_eq!(numeric_unit_kanji("せんち"), None);
-        assert_eq!(numeric_unit_kanji("まんが"), None);
-        assert_eq!(numeric_unit_kanji("かわ"), None);
-    }
-
-    #[test]
     fn digit_plus_unit_is_rejected_by_digit_verification() {
         // 「5万」は verify_digits_preserved を通らない（万が 10000 と読まれる）。
         // この性質があるため、救済候補は verify の後に差し込む必要がある。
@@ -1328,5 +1340,42 @@ mod tests {
         assert!(runs[0].is_digit());
         assert_eq!(runs[0].text(), "5");
         assert_eq!(runs[1].text(), "まん");
+    }
+    #[test]
+    #[test]
+    fn numeric_unit_promotion_depends_on_ambiguity() {
+        // 数字の直後でほぼ一意 → 第 1 候補に置いてよい
+        assert_eq!(numeric_unit_kanji("まん"), Some(("万", true)));
+        assert_eq!(numeric_unit_kanji("おく"), Some(("億", true)));
+
+        // 同音異義語あり → 候補には入れるが順位は LLM に譲る
+        // 3せん=3戦/3選, 1ちょう=1丁, 5じゅう=5重
+        assert_eq!(numeric_unit_kanji("せん"), Some(("千", false)));
+        assert_eq!(numeric_unit_kanji("ちょう"), Some(("兆", false)));
+        assert_eq!(numeric_unit_kanji("じゅう"), Some(("十", false)));
+        assert_eq!(numeric_unit_kanji("ひゃく"), Some(("百", false)));
+
+        // 前方一致では拾わない
+        assert_eq!(numeric_unit_kanji("まんが"), None);
+        assert_eq!(numeric_unit_kanji("せんち"), None);
+        assert_eq!(numeric_unit_kanji("かわ"), None);
+    }
+
+    #[test]
+    fn numeric_unit_rule_does_not_apply_when_context_follows() {
+        // 「5せんのしはらい」「5せんをかちぬいた」は かな run が数詞に
+        // 完全一致しないので、このルールは発動せず文脈ごと LLM に渡る。
+        for reading in ["5せんのしはらい", "5せんをかちぬいた", "5まんえん"] {
+            let runs = split_by_digits(reading);
+            assert_eq!(runs.len(), 2, "{reading}");
+            let Run::Kana(k) = &runs[1] else {
+                panic!("{reading}: 2 番目が Kana ではない")
+            };
+            assert_eq!(
+                numeric_unit_kanji(k),
+                None,
+                "{reading}: かな run \"{k}\" で発動してはいけない"
+            );
+        }
     }
 }

--- a/crates/rakukan-engine/src/digits.rs
+++ b/crates/rakukan-engine/src/digits.rs
@@ -755,6 +755,33 @@ pub fn verify_digits_preserved(input: &str, output: &str) -> bool {
     extract_digits(input) == extract_digits(output)
 }
 
+/// 数字 run の直後に単独で現れたとき、数詞（位取りの単位）として解釈すべき読み。
+///
+/// 辞書は「まん → 万」を正しく持っているが、数字が混ざる読みは
+/// `convert_with_digit_protection` が run 単位で `KanaKanjiConverter::convert()`
+/// を呼ぶ経路になり、そこは LLM のみで辞書を参照しない。その結果
+/// 「5まん」が「5満」「5マン」になる。数字の直後という限定した条件でのみ、
+/// 数詞の漢字を先頭に差し込んで救済する。
+///
+/// 完全一致のみを対象にしているのは誤爆を避けるため。前方一致にすると
+/// 「3せんち」(3センチ) が「3千ち」になるなど、実在する読みを壊す。
+///
+/// なお、この救済候補を run の候補リストに差し込んで `combine_runs` に通すのは
+/// 誤り。`verify_digits_preserved` が「万」を数値 10000 と読むため
+/// 「5万」が数字改変とみなされて捨てられ、生成順の都合で候補が全滅しうる。
+/// 呼び出し側は verify の後に直接差し込むこと。
+fn numeric_unit_kanji(reading: &str) -> Option<&'static str> {
+    match reading {
+        "じゅう" => Some("十"),
+        "ひゃく" => Some("百"),
+        "せん" => Some("千"),
+        "まん" => Some("万"),
+        "おく" => Some("億"),
+        "ちょう" => Some("兆"),
+        _ => None,
+    }
+}
+
 fn build_local_context(runs: &[Run], kana_index: usize, global_context: &str) -> String {
     let mut ctx = String::from(global_context);
     if kana_index > 0
@@ -822,10 +849,25 @@ pub fn convert_with_digit_protection(
 
     let combined = combine_runs(&run_candidates, num_candidates);
 
-    let verified: Vec<String> = combined
+    let mut verified: Vec<String> = combined
         .into_iter()
         .filter(|c| verify_digits_preserved(reading, c))
         .collect();
+
+    // 「5まん」→「5万」の救済。
+    //
+    // この候補は verify_digits_preserved を意図的に通していない。extract_digits() は
+    // 「万」を数値 10000 として読むため、入力「5まん」の数字 "5" と出力「5万」の
+    // "5"+"10000" が一致せず、数字が改変されたと誤判定されて捨てられてしまう。
+    // ここは数字 run と数詞をこちらで組み立てており、数字が保存されていることは
+    // 自明なので、フィルタの後に直接差し込む。
+    if let [Run::Digit(d), Run::Kana(k)] = runs.as_slice() {
+        if let Some(unit) = numeric_unit_kanji(k) {
+            let cand = format!("{d}{unit}");
+            verified.retain(|c| c != &cand);
+            verified.insert(0, cand);
+        }
+    }
 
     if verified.is_empty() {
         Ok(vec![reading.to_string()])
@@ -1257,5 +1299,34 @@ mod tests {
         ];
         let result = combine_runs(&runs, 3);
         assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn numeric_unit_after_digit_is_recognized() {
+        assert_eq!(numeric_unit_kanji("まん"), Some("万"));
+        assert_eq!(numeric_unit_kanji("おく"), Some("億"));
+        assert_eq!(numeric_unit_kanji("せん"), Some("千"));
+        // 前方一致にすると「3せんち」を壊すので、完全一致のみ
+        assert_eq!(numeric_unit_kanji("せんち"), None);
+        assert_eq!(numeric_unit_kanji("まんが"), None);
+        assert_eq!(numeric_unit_kanji("かわ"), None);
+    }
+
+    #[test]
+    fn digit_plus_unit_is_rejected_by_digit_verification() {
+        // 「5万」は verify_digits_preserved を通らない（万が 10000 と読まれる）。
+        // この性質があるため、救済候補は verify の後に差し込む必要がある。
+        assert!(!verify_digits_preserved("5まん", "5万"));
+        // 一方、単位を伴わない通常の候補は通る
+        assert!(verify_digits_preserved("5まん", "5マン"));
+    }
+
+    #[test]
+    fn split_by_digits_splits_digit_and_kana() {
+        let runs = split_by_digits("5まん");
+        assert_eq!(runs.len(), 2);
+        assert!(runs[0].is_digit());
+        assert_eq!(runs[0].text(), "5");
+        assert_eq!(runs[1].text(), "まん");
     }
 }


### PR DESCRIPTION
#6 の修正です。

## 問題

`5まん` を変換すると `5満` / `5マン` になり、**`5万` が候補に一切出ません**。

| 読み | 結果 | |
| --- | --- | --- |
| `まん` | 万 | OK |
| `5まん` | 5満 → 5マン | NG |

## 原因

`convert_with_digit_protection()` はかな run を `KanaKanjiConverter::convert()` に
渡しますが、これは LLM のみで辞書を参照しません。辞書引きは読み全体に対して
行われるため `5まん` という読みは辞書に無く、「まん → 万」という正解を
持っているのに参照されない状態でした。

```
reading="まん"    source=dict  first_candidate="万"    (正しい)
reading="5まん"   source=bg    first_candidate="5満"   (誤り)
```

`model_variant` を `jinen-v1-xsmall-q5` から `jinen-v2-small-f16`（約 7 倍）に
変えても `5満` が `5マン` になるだけで改善しなかったため、モデルの精度ではなく
経路の問題と判断しました。

## 修正

数字 run の直後にかな run が単独で来て、それが数詞（じゅう / ひゃく / せん /
まん / おく / ちょう）に**完全一致**する場合のみ、対応する漢数字単位を候補の
先頭に差し込みます。

前方一致にしていないのは誤爆を避けるためです。前方一致だと `3せんち` (3センチ)
が `3千ち` になるなど、実在する読みを壊します。

## 実装上の注意（テストで固定しています）

この候補は `verify_digits_preserved` を**意図的に通していません**。
`extract_digits()` は「万」を数値 10000 として読むため、入力 `5まん` の数字 `"5"` と
出力 `5万` の `"5"+"10000"` が一致せず、数字が改変されたと誤判定されて捨てられます。

そのため run の候補リストに混ぜて `combine_runs` に通してはいけません。生成順の
都合で上位が全て単位付き候補になり、それらが軒並みフィルタで落ちて**候補が全滅**
します（最初にその実装を試して実際に全滅しました）。verify の後に直接差し込みます。

`digit_plus_unit_is_rejected_by_digit_verification` でこの性質を固定してあるので、
将来同じ設計に戻そうとしてもテストで気づけます。

## 動作確認

- Windows 11 Pro 10.0.26200 / `gpu_backend = "vulkan"`
- 修正後: `5まん` → `5万` が第 1 候補。`5マン` `５マン` `五マン` も候補に残る
- `cargo test -p rakukan-engine --release --lib digits` … 40 passed / 0 failed