### PR TITLE
fix(tsf): bg/poll 経路でも読みを明示的に渡す（ユーザー辞書・学習履歴が反映されない）

### DIFF
--- a/crates/rakukan-tsf/src/tsf/candidate_window.rs
+++ b/crates/rakukan-tsf/src/tsf/candidate_window.rs
@@ -907,22 +907,25 @@ pub fn on_waiting_timer() {
             let mut guard = engine_get().ok()?;
             let engine = guard.as_mut()?;
             let hira_key = engine.hiragana_text();
-            let llm_cands = engine.bg_take_candidates(&preedit_key).or_else(|| {
-                if hira_key != preedit_key {
+            // 候補を取得できたキーを覚えておく。preedit_key は pending_romaji を
+            // 含む（例「たt」）ことがあり、その場合フォールバックした hira_key
+            // （例「た」）が実際の読み。マージも同じキーで引く必要がある。
+            let (matched_key, llm_cands) = match engine.bg_take_candidates(&preedit_key) {
+                Some(c) => (preedit_key.clone(), c),
+                None if hira_key != preedit_key => {
                     tracing::debug!(
                         "on_waiting_timer(selecting): key mismatch, retry hira={:?}",
                         hira_key
                     );
-                    engine.bg_take_candidates(&hira_key)
-                } else {
-                    None
+                    (hira_key.clone(), engine.bg_take_candidates(&hira_key)?)
                 }
-            })?;
+                None => return None,
+            };
             // 読みを明示的に渡す。merge_candidates() はエンジン内部の
             // hiragana_buf を見るため、この経路ではユーザー辞書・学習履歴が
             // 引けずに LLM 候補だけになる（protocol v4 で追加された
             // MergeCandidatesForReading への移行漏れ）。
-            let merged = engine.merge_candidates_for_reading(&preedit_key, llm_cands, DICT_LIMIT);
+            let merged = engine.merge_candidates_for_reading(&matched_key, llm_cands, DICT_LIMIT);
             if merged.is_empty() {
                 None
             } else {
@@ -1060,16 +1063,20 @@ pub fn on_waiting_timer() {
         // wait_preedit は preedit_display()（pending_romaji 含む）なので不一致の場合がある。
         // hiragana_text() でフォールバックして両方試す。
         let hira_key = engine.hiragana_text();
-        let llm_cands = engine.bg_take_candidates(&wait_preedit).or_else(|| {
-            if hira_key != wait_preedit {
+        // 取得できたキーを覚えておく。マージも同じキーで引かないと、
+        // フォールバックが効いた時にユーザー辞書・学習履歴が引けない。
+        let taken = match engine.bg_take_candidates(&wait_preedit) {
+            Some(c) => Some((wait_preedit.clone(), c)),
+            None if hira_key != wait_preedit => {
                 tracing::debug!("on_waiting_timer: key mismatch, retry hira={:?}", hira_key);
-                engine.bg_take_candidates(&hira_key)
-            } else {
-                None
+                engine
+                    .bg_take_candidates(&hira_key)
+                    .map(|c| (hira_key.clone(), c))
             }
-        });
+            None => None,
+        };
 
-        let llm_cands = match llm_cands {
+        let (matched_key, llm_cands) = match taken {
             Some(c) => c,
             None => {
                 // キー不一致 → bg_reclaim して bg_start で正しいキーで再起動
@@ -1092,8 +1099,8 @@ pub fn on_waiting_timer() {
         };
 
         // 読みを明示的に渡す（merge_candidates() は内部バッファ参照のため
-        // ユーザー辞書・学習履歴が反映されない）。
-        let merged = engine.merge_candidates_for_reading(&wait_preedit, llm_cands, DICT_LIMIT);
+        // ユーザー辞書・学習履歴が反映されない）。キーは実際に候補が取れた方。
+        let merged = engine.merge_candidates_for_reading(&matched_key, llm_cands, DICT_LIMIT);
         if merged.is_empty() {
             return None;
         }

--- a/crates/rakukan-tsf/src/tsf/candidate_window.rs
+++ b/crates/rakukan-tsf/src/tsf/candidate_window.rs
@@ -918,7 +918,11 @@ pub fn on_waiting_timer() {
                     None
                 }
             })?;
-            let merged = engine.merge_candidates(llm_cands, DICT_LIMIT);
+            // 読みを明示的に渡す。merge_candidates() はエンジン内部の
+            // hiragana_buf を見るため、この経路ではユーザー辞書・学習履歴が
+            // 引けずに LLM 候補だけになる（protocol v4 で追加された
+            // MergeCandidatesForReading への移行漏れ）。
+            let merged = engine.merge_candidates_for_reading(&preedit_key, llm_cands, DICT_LIMIT);
             if merged.is_empty() {
                 None
             } else {
@@ -1087,11 +1091,9 @@ pub fn on_waiting_timer() {
             }
         };
 
-        let merged = if llm_cands.is_empty() {
-            engine.merge_candidates(vec![], DICT_LIMIT)
-        } else {
-            engine.merge_candidates(llm_cands, DICT_LIMIT)
-        };
+        // 読みを明示的に渡す（merge_candidates() は内部バッファ参照のため
+        // ユーザー辞書・学習履歴が反映されない）。
+        let merged = engine.merge_candidates_for_reading(&wait_preedit, llm_cands, DICT_LIMIT);
         if merged.is_empty() {
             return None;
         }

--- a/crates/rakukan-tsf/src/tsf/factory.rs
+++ b/crates/rakukan-tsf/src/tsf/factory.rs
@@ -1046,7 +1046,7 @@ fn engine_convert_sync_multi(
     let _ = llm_limit; // DynEngine::convert_sync は num_candidates を内部設定から読む
 
     // 辞書候補とマージ（dict_limit 件まで）
-    let merged = engine.merge_candidates(llm_cands, dict_limit);
+    let merged = engine.merge_candidates_for_reading(preedit, llm_cands, dict_limit);
     tracing::debug!("merge_candidates → {:?}", merged);
     if merged.is_empty() {
         vec![preedit.to_string()]

--- a/crates/rakukan-tsf/src/tsf/factory/dispatch.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/dispatch.rs
@@ -207,7 +207,14 @@ impl super::TextServiceFactory_Impl {
                                 "poll: bg_take_candidates → Some({} cands)",
                                 llm_cands.len()
                             );
-                            let merged = engine.merge_candidates(llm_cands, DICT_LIMIT_POLL);
+                            // 読みを明示的に渡す（merge_candidates() は内部
+                            // バッファ参照のため、ユーザー辞書・学習履歴が
+                            // 反映されず LLM 候補だけになる）。
+                            let merged = engine.merge_candidates_for_reading(
+                                &preedit_key,
+                                llm_cands,
+                                DICT_LIMIT_POLL,
+                            );
                             tracing::debug!("poll: merge_candidates → {:?}", merged);
                             if !merged.is_empty() {
                                 sess.replace_selecting_candidates(merged, CandidateViewSource::Bg);

--- a/crates/rakukan-tsf/src/tsf/factory/dispatch.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/dispatch.rs
@@ -309,9 +309,17 @@ impl super::TextServiceFactory_Impl {
                                 bg_timeout_watchdog(false); // 回復 → ウォッチドッグリセット
                                 // LLM候補とマージ。llm_cands が空でも辞書候補がある場合はそちらを使う。
                                 let merged = if llm_cands.is_empty() {
-                                    engine.merge_candidates(vec![], DICT_LIMIT_WAIT)
+                                    engine.merge_candidates_for_reading(
+                                        &wait_preedit,
+                                        vec![],
+                                        DICT_LIMIT_WAIT,
+                                    )
                                 } else {
-                                    engine.merge_candidates(llm_cands, DICT_LIMIT_WAIT)
+                                    engine.merge_candidates_for_reading(
+                                        &wait_preedit,
+                                        llm_cands,
+                                        DICT_LIMIT_WAIT,
+                                    )
                                 };
                                 tracing::debug!("waiting-poll: merged={} cands", merged.len());
                                 // preedit 1件だけでも候補ウィンドウを出す（辞書/LLMどちらかにヒットした）

--- a/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
@@ -157,7 +157,7 @@ fn immediate_dict_candidates(
     preedit: &str,
     dict_limit: usize,
 ) -> Option<Vec<String>> {
-    let candidates = engine.merge_candidates(vec![], dict_limit);
+    let candidates = engine.merge_candidates_for_reading(preedit, vec![], dict_limit);
     let has_conversion = candidates.iter().any(|candidate| candidate != preedit);
     if has_conversion {
         Some(candidates)
@@ -336,7 +336,8 @@ impl super::TextServiceFactory_Impl {
 
                 // inline 完走 → 取得してマージ
                 let llm_cands = engine.bg_take_candidates(&target).unwrap_or_default();
-                let candidates = engine.merge_candidates(llm_cands, DICT_LIMIT);
+                let candidates =
+                    engine.merge_candidates_for_reading(&target, llm_cands, DICT_LIMIT);
                 let candidates = if candidates.is_empty() {
                     vec![target.clone()]
                 } else {
@@ -453,7 +454,8 @@ impl super::TextServiceFactory_Impl {
                                     "on_convert[llm_pending]: bg_take_candidates → Some({} cands)",
                                     llm_cands.len()
                                 );
-                                let merged = engine.merge_candidates(llm_cands, DICT_LIMIT);
+                                let merged = engine
+                                    .merge_candidates_for_reading(&take_key, llm_cands, DICT_LIMIT);
                                 tracing::debug!("merge_candidates → {:?}", merged);
                                 tracing::debug!(
                                     "on_convert[llm_pending]: merged={} cands",
@@ -555,7 +557,9 @@ impl super::TextServiceFactory_Impl {
                                         "on_convert[llm_pending]: reclaim+retry → Some({} cands)",
                                         llm_cands.len()
                                     );
-                                    let merged = engine.merge_candidates(llm_cands, DICT_LIMIT);
+                                    let merged = engine.merge_candidates_for_reading(
+                                        &take_key, llm_cands, DICT_LIMIT,
+                                    );
                                     tracing::debug!("merge_candidates → {:?}", merged);
                                     if !merged.is_empty() {
                                         if let Ok(mut sess2) = session_get() {
@@ -1274,7 +1278,7 @@ impl super::TextServiceFactory_Impl {
                 };
                 // bg_take_candidates 成功時に kanji が復元されているため再評価
                 let kanji_ready_now = engine.is_kanji_ready();
-                let merged = engine.merge_candidates(llm_cands, DICT_LIMIT);
+                let merged = engine.merge_candidates_for_reading(&preedit, llm_cands, DICT_LIMIT);
                 convert_mark("merge_candidates", convert_start, &mut convert_last);
                 tracing::debug!(
                     "merge_candidates(kanji_ready={}) → {:?} [dict: {:?}]",


### PR DESCRIPTION
#9 の修正です。

## 問題

Space 変換の候補にユーザー辞書と学習履歴が反映されず、LLM 候補だけが出ます。

`user_dict.toml` に `さんかく → ["三角", "△", "▲", "▽", "▼"]` を登録しても、
候補は「三角 / 参画 / さんかく / サンカク / 三鶴 / 産殻」となり記号が出ません。
一方 `かぎかっこ → ["「」", "『』"]` は正しく出ます。

ログ上の違いはここでした。

```
かぎかっこ  source=dict            first_candidate="「」"   ← 反映される
さんかく    source=live_preview → bg  first_candidate="三角"  ← 反映されない
```

辞書層自体は正常です（`load_dict()` を直接呼んで確認）。

```
lookup_user(さんかく) = ["三角", "△", "▲", "▽", "▼"]
```

## 原因

候補マージに 2 系統あります。

| API | 読みの取得元 |
| --- | --- |
| `merge_candidates(llm, limit)` | `self.hiragana_buf`（エンジン内部） |
| `merge_candidates_for_reading(reading, llm, limit)` | 引数（protocol v4 で追加） |

エンジンはホストプロセス側にあるため `hiragana_buf` が同期されておらず、前者では
空（または古い）読みで辞書を引くことになり、ユーザー辞書と学習履歴が落ちます。

bg / poll の 3 箇所が古い `merge_candidates` のまま残っていました。辞書プレビュー
経路は既に `merge_candidates_for_reading` を使っているため、**同じユーザー辞書でも
読みによって効いたり効かなかったりする**という分かりにくい症状になっていました。

`merge_candidates_for_reading_uses_given_reading_not_internal_buffer` という
テストが既にあるので、この取り違え自体は認識されていて、v4 での移行が一部
残っていたという理解です。

## 変更

3 箇所で読みを明示的に渡すようにしました。読みはいずれもその場で利用可能でした
（`preedit_key` / `wait_preedit`）。

- `tsf/candidate_window.rs`（2 箇所）
- `tsf/factory/dispatch.rs`（1 箇所）

## 動作確認

- Windows 11 Pro 10.0.26200 / `gpu_backend = "vulkan"`
- 修正後、`さんかく` の候補に △ ▲ ▽ ▼ が並ぶことを確認
- `cargo build -p rakukan-tsf --release` … 警告なし

## 補足

`merge_candidates()` は呼び出し側が読みを取り違えやすい API に見えます。
将来的には `merge_candidates_for_reading()` に一本化して前者を削除するか、
`#[deprecated]` を付けておくと同種の移行漏れを防げそうです。