### PR TITLE
style: cargo fmt --all を適用して Format Check を通す

### DIFF
--- a/crates/rakukan-engine/src/kanji/llamacpp.rs
+++ b/crates/rakukan-engine/src/kanji/llamacpp.rs
@@ -561,9 +561,7 @@ impl LlamaCppModel {
 
         // n_ctx / n_batch は「全 beam のフル系列を 1 decode に載せる」ぶんが必要。
         let max_seq_len = input_len.saturating_add(max_new_tokens).saturating_add(1);
-        let batch_size = max_seq_len
-            .saturating_mul(beam_size)
-            .min(u32::MAX as usize) as u32;
+        let batch_size = max_seq_len.saturating_mul(beam_size).min(u32::MAX as usize) as u32;
         let n_ctx_needed = batch_size.max(self.n_ctx);
         let ctx_params = self
             .context_params()

--- a/crates/rakukan-tsf/src/tsf/factory/on_compose.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_compose.rs
@@ -654,7 +654,10 @@ pub(super) fn end_composition(ctx: ITfContext, tid: u32, text: String) -> Result
         }
 
         comp.EndComposition(ec).map_err(|e| {
-            tracing::warn!("end_composition: EndComposition failed text={:?}: {e}", text);
+            tracing::warn!(
+                "end_composition: EndComposition failed text={:?}: {e}",
+                text
+            );
             windows::core::Error::new(E_FAIL, format!("EndComposition: {e}"))
         })?;
         Ok(())


### PR DESCRIPTION
#14 のうち **Format Check の 2 箇所だけ** を直します。`cargo fmt --all` の出力そのままで、挙動は変わりません。

- `crates/rakukan-engine/src/kanji/llamacpp.rs:561`
- `crates/rakukan-tsf/src/tsf/factory/on_compose.rs:654`

差分は 2 ファイル・5 行追加 / 4 行削除です。

**clippy 側（Build & Test）はこの PR に含めていません。** 調べたところ、`cargo clippy --workspace -- -D warnings` はクレート単位で次々に止まり、`build.rs` → `rakukan-dict-builder` → `rakukan-tray` → `rakukan-engine-rpc` → … と連鎖します。最後まで通そうとすると `rakukan-engine` と `rakukan-tsf` にも及び、リポジトリ全体の lint 移行になります（`--all-targets` 込みで `cargo clippy --fix` を試したところ 29 ファイル / 700 行超になりました）。

これは現在開いている #5 / #7 / #12 と同じファイルに当たるため、先に入れると各 PR の rebase が必要になります。順序の判断は作者にお任せするのが良いと思い、この PR は fmt だけに留めました。clippy 側も必要でしたら別途出します。

内訳（clippy が新しくなって一斉に出はじめたもの）:

- `manual implementation of .is_multiple_of()` — `crates/rakukan-engine/build.rs`、`crates/rakukan-tsf/build.rs`
- `you seem to use .enumerate() and immediately discard the index` — `rakukan-dict-builder`
- `casting to the same type is unnecessary` / `field assignment outside of initializer` — `rakukan-tray`
- `this if statement can be collapsed` / `this can be std::io::Error::other(_)` — `rakukan-engine-rpc`
- 以降 `rakukan-dict` などが続きます