### PR TITLE
fix(tsf): 打鍵のたびにキャレット矩形を更新し、予測ウィンドウが画面左上へ飛ぶのを直す

### DIFF
--- a/crates/rakukan-tsf/src/tsf/factory/on_compose.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_compose.rs
@@ -218,6 +218,33 @@ pub(super) fn update_composition(
             let _ = ctx.SetSelection(ec, &[sel]);
         }
 
+        // 打鍵のたびにキャレット矩形を更新する。
+        // 予測ウィンドウ（`suggestion::show`）と候補ウィンドウは `caret_rect_get()` を
+        // 見るが、CARET_RECT を更新するのは Space 押下（`update_caret_rect`）と
+        // `commit_then_start_composition` だけだった。そのため、プロセス内で
+        // 一度も変換・確定を挟んでいない入力では初期値 (0,0,0,0) のままになり、
+        // 予測ウィンドウがプライマリモニタの左上に出てしまう。
+        if let Ok(view) = ctx.GetActiveView() {
+            use windows::Win32::Foundation::RECT;
+            let mut rect = RECT::default();
+            let mut clipped = windows::Win32::Foundation::BOOL(0);
+            match view.GetTextExt(ec, &range, &mut rect, &mut clipped) {
+                Ok(()) => {
+                    // 全ゼロは「取れなかった」と同義（成功を返しつつ空矩形を
+                    // 返すアプリがある）。古い正しい値を壊さないよう捨てる。
+                    if rect.bottom != 0 || rect.left != 0 {
+                        caret_rect_set(rect);
+                        crate::tsf::candidate_window::reposition(rect.left, rect.bottom);
+                    } else {
+                        tracing::debug!("update_composition: GetTextExt returned empty rect");
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("update_composition: GetTextExt failed: {e}");
+                }
+            }
+        }
+
         Ok(())
     });
     unsafe {


### PR DESCRIPTION
## 症状

**そのプロセスで一度も変換・確定をしていない状態で打つと、予測ウィンドウがプライマリモニタの左上隅に出ます。** 一度 Space で変換するか Enter で確定すると、以降は正しい位置に付いてきます。「アプリを開いて最初の 1 回だけ位置がおかしい」という形で出ます。

## 原因

`CARET_RECT` を更新しているのは次の 2 経路だけです。

| 経路 | 呼ばれる時 |
|---|---|
| `on_compose.rs` `update_caret_rect()` | Space 押下時（`on_convert.rs`） |
| `on_compose.rs` `commit_then_start_composition()` | 確定して次の composition を張る時 |

通常の打鍵で走る `update_composition()` は更新していません。一方、予測ウィンドウ（`suggestion::show`）と候補ウィンドウは `caret_rect_get()` を表示位置に使います（`dispatch.rs` / `edit_ops.rs`）。したがって上の 2 経路をまだ一度も通っていない間は初期値 `(0,0,0,0)` が読まれます。

## 変更

`update_composition()` の EditSession 内、`SetSelection` の直後で `GetTextExt()` を引いて `caret_rect_set()` します。

- **既に走っている EditSession の中で取るので、追加の `RequestEditSession` は発生しません。**
- 更新後に `candidate_window::reposition()` を呼びます（非表示なら no-op）。これは `commit_then_start_composition()` が既に取っている手順と同じで、そこからのコピーです。
- `GetTextExt()` が `Ok` を返しつつ全ゼロの矩形を返すアプリがあるため、**全ゼロは「取得できなかった」とみなして既存の値を上書きしません。** 取得失敗と空矩形は DEBUG ログに残します。

## 確認

- `cargo test -p rakukan-tsf --release` — 93 passed / 0 failed
- `cargo clippy -p rakukan-tsf --release -- -D warnings` — 警告なし
- `cargo fmt --all -- --check` — 差分なし

位置計算そのものは既存の `commit_then_start_composition()` と同じ経路を使うので、表示位置のロジックは変えていません。**実機での確認は、この経路が通っていない状態（プロセス起動直後の 1 打鍵目）で予測ウィンドウが出る位置を見るのが早いです。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
