### PR TITLE
fix(tsf): 一度も変換されていない読みが Enter でそのまま確定されるのを直す

### DIFF
--- a/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
@@ -1932,6 +1932,10 @@ impl super::TextServiceFactory_Impl {
 /// 存在しない」ときだけ。通常はここに入らず即座に確定する。
 const LIVE_COMMIT_CATCHUP_MS: u64 = 400;
 
+/// bg をこの場で起動し直した場合の待ち上限。先頭から変換するぶん長く見る
+/// (実測: 24 文字で 149ms、beam_size=3)。
+const LIVE_COMMIT_RESTART_CATCHUP_MS: u64 = 1_000;
+
 /// ライブ変換の preview を、必要なら bg 変換の完了を待って取り直す。
 ///
 /// ライブ変換の preview は変換が追いつかない間 `live_continuation_display` が
@@ -1941,6 +1945,9 @@ const LIVE_COMMIT_CATCHUP_MS: u64 = 400;
 ///
 /// 現在の読みに対する変換結果が無い場合だけ短時間待って拾い直し、結果が既に
 /// ある場合も含めて、必ず `merge_candidates_for_reading` を通した値を返す。
+/// 待つのは bg が走っているときだけでなく、走っていない場合はその読みで bg を
+/// 起動してから待つ（打鍵が速いと `on_live_timer` が FIRED しないまま Enter が
+/// 来るため、bg=done のまま「一度も変換されていない読み」が確定していた）。
 /// 「結果があるなら preview はそれを反映済み」とは限らないためで、ライブ
 /// タイマーは `pass_debounce()` で最終打鍵から `debounce_ms` 経過するまで
 /// 発火せず、その猶予の内に Enter が来ると伸ばしたままの preview が残る
@@ -1957,15 +1964,41 @@ fn catch_up_live_preview(
     let top = match engine.bg_peek_top_candidate(reading) {
         Some(top) => top,
         None => {
-            if engine.bg_status() != "running" {
-                return (preview, false);
-            }
-            let completed = engine.bg_wait_ms(LIVE_COMMIT_CATCHUP_MS);
+            // bg が running でない ＝ 現在の読みは一度も変換に渡されていない。打鍵が
+            // 速いと on_live_timer が FIRED しないまま Enter が来るため（2026-09-01:
+            // 1.2 秒間 preview が更新されず「これ、漫画ではコマを分けてひょうげんして
+            // いるけど」が確定した）、ここで自分から bg を起動して待つ。
+            let restarted = if engine.bg_status() == "running" {
+                false
+            } else {
+                let Some(n_cands) = crate::engine::state::live_bg_start_n_cands(reading) else {
+                    tracing::info!("[Live] commit catch-up: bg not startable for {:?}", reading);
+                    return (preview, true);
+                };
+                if !engine.bg_start(n_cands) {
+                    tracing::info!(
+                        "[Live] commit catch-up: bg_start refused for {:?} (status={})",
+                        reading,
+                        engine.bg_status()
+                    );
+                    return (preview, true);
+                }
+                tracing::info!("[Live] commit catch-up: started bg for {:?}", reading);
+                true
+            };
+            // 起動し直した場合は先頭から変換するので待ち上限を伸ばす。
+            let budget = if restarted {
+                LIVE_COMMIT_RESTART_CATCHUP_MS
+            } else {
+                LIVE_COMMIT_CATCHUP_MS
+            };
+            let completed = engine.bg_wait_ms(budget);
             let Some(top) = engine.bg_peek_top_candidate(reading) else {
                 tracing::info!(
-                    "[Live] commit catch-up: no result for {:?} (completed={})",
+                    "[Live] commit catch-up: no result for {:?} (completed={} budget={}ms)",
                     reading,
-                    completed
+                    completed,
+                    budget
                 );
                 return (preview, true);
             };


### PR DESCRIPTION
Issue #18 の C（Enter / 確定まわり）の 2 件目です。

> ⚠ **この PR は #19 の上に積んでいます。** 同じ関数（`catch_up_live_preview`）を触るため分離できませんでした。差分に #19 のコミットが 1 本含まれるので、**#19 をマージしたあとにご覧ください**（#19 マージ後は自動的にこの PR の差分だけになります）。レビューは `3c907ee` の 1 コミットが対象です。

## 症状

#19 で塞いだのとは**別経路**で、同じ「未変換のかながそのまま確定される」が残ります。

実測（2026-09-01）: preview が `これ、漫画ではコマを分けて` になったあと、**1.2 秒間 preview が一度も更新されないまま Enter が押され、`これ、漫画ではコマを分けてひょうげんしているけど` が確定しました。** エンジン側は同じ時間帯に `reading_chars` 14 → 24 まで変換を回しているので、**結果を取りに行けていなかったのは TSF 側です。**

## 原因

打鍵が速いと `on_live_timer` が FIRED しないまま Enter が来ます。この場合 bg は「1 つ前の読みで done」の状態なので、#19 で入れた `catch_up_live_preview()` の

```rust
if engine.bg_status() != "running" {
    return (preview, false);   // ← 素通し
}
```

に落ちて何もせず返ります。**しかも `unconverged = false` を返すため、壊れた表記がそのまま学習に流れます**（`learn_history` に実物が載っていました）。

## 変更

現在の読みの結果が無く bg も走っていないなら、**その場で `bg_start()` してから待つ**ようにしました。

- 待ち上限はこの場合だけ 1000ms（`LIVE_COMMIT_RESTART_CATCHUP_MS`）にしています。**進行中の変換の完了を待つ #19 の 400ms と違い、先頭から変換し直すためです。** 実測は 24 文字で 149ms（`beam_size=3`）なので余裕を見た値です。
- `live_bg_start_n_cands()` が `None` を返す場合と `bg_start()` が拒否した場合は、**従来どおり `unconverged = true` で学習を見送ります。** 待っても取れなかった場合も同じです。
- 素通しだった経路が無くなるので、`unconverged = false` を返すのは「実際に現在の読みの変換結果が取れたとき」だけになります。

## 確認

- `cargo test -p rakukan-tsf --release` — 93 passed / 0 failed
- `cargo clippy -p rakukan-tsf --release --all-targets -- -D warnings` — 警告なし
- `cargo fmt --all -- --check` — 差分なし

元のコミットには学習履歴の汚染を洗い出す使い捨てプローブ（`tail_kana_probe.rs`）も入っていましたが、**手元の学習履歴を 1 件ずつ見て消すための道具で汎用性が無いので外しました。** 必要であれば別途出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
