### PR TITLE
fix(tsf): Enter で読点を含む文が細切れに確定されるのを直す

### DIFF
--- a/crates/rakukan-tsf/src/engine/state.rs
+++ b/crates/rakukan-tsf/src/engine/state.rs
@@ -1200,28 +1200,23 @@ pub enum SessionState {
     /// 区読点分割変換モード。
     ///
     /// Space 押下時に読みが区読点（、。！？）を含む場合に遷移する。
-    /// 全ブロックを事前に変換し、Enter キーで 1 ブロックずつ確定する。
+    /// 全ブロックを事前に変換し、← / → でブロックを選び直して Enter で全体を確定する。
     ///
     /// - `blocks`: 分割・変換済みブロック一覧
     /// - `current_index`: 現在フォーカス中のブロックインデックス
     /// - `full_reading`: ESC で戻るための元の全体読み
-    /// - `pos_x`, `pos_y`: 候補ウィンドウ表示位置
     ///
     /// 遷移:
     ///   Space / CandidateNext → 現在ブロックの次候補へ
     ///   CandidatePrev         → 現在ブロックの前候補へ
-    ///   Enter  → 現在ブロック確定。次ブロックへ移行。最終ブロックなら全確定。
+    ///   CursorLeft / CursorRight → フォーカスするブロックを前後へ移動
+    ///   Enter  → 全ブロックをまとめて確定。
     ///   ESC    → 全ブロック解除、full_reading をプリエディットへ復元。
     ///   Input  → 現在状態を確定してから文字を通常入力（Selecting 相当）。
     BlockSelecting {
         blocks: Vec<ConversionBlock>,
         current_index: usize,
         full_reading: String,
-        /// Enter で1ブロックずつ確定した際に積算するコミット済みテキスト。
-        /// 学習・最終コミット時に全体テキストとして使う。
-        committed_prefix: String,
-        pos_x: i32,
-        pos_y: i32,
     },
     /// ライブ変換表示中。
     ///
@@ -1294,20 +1289,11 @@ fn candidate_views_from_strings(
 impl SessionState {
     // ── BlockSelecting ──────────────────────────────────────────────────────
 
-    pub fn set_block_selecting(
-        &mut self,
-        blocks: Vec<ConversionBlock>,
-        full_reading: String,
-        pos_x: i32,
-        pos_y: i32,
-    ) {
+    pub fn set_block_selecting(&mut self, blocks: Vec<ConversionBlock>, full_reading: String) {
         *self = SessionState::BlockSelecting {
             blocks,
             current_index: 0,
             full_reading,
-            committed_prefix: String::new(),
-            pos_x,
-            pos_y,
         };
         SESSION_SELECTING.store(true, std::sync::atomic::Ordering::Release);
     }
@@ -1403,7 +1389,7 @@ impl SessionState {
 
     /// BlockSelecting: composition 表示用の (prefix, cand_text, remainder) を返す。
     ///
-    /// - `prefix`   : current_index より前のブロックのテキスト（確定済みイメージ）
+    /// - `prefix`   : current_index より前のブロックのテキスト（composition に載る）
     /// - `cand_text`: 現在ブロックの選択候補
     /// - `remainder`: current_index より後のブロックのテキスト（区読点含む）+ 現在の区読点
     pub fn block_selecting_composition_parts(&self) -> Option<(String, String, String)> {
@@ -1471,15 +1457,6 @@ impl SessionState {
         }
     }
 
-    /// BlockSelecting: pos_x, pos_y を返す。
-    pub fn block_selecting_pos(&self) -> Option<(i32, i32)> {
-        if let SessionState::BlockSelecting { pos_x, pos_y, .. } = self {
-            Some((*pos_x, *pos_y))
-        } else {
-            None
-        }
-    }
-
     /// BlockSelecting: full_reading を返す（ESC 用）。
     pub fn block_selecting_full_reading(&self) -> Option<String> {
         if let SessionState::BlockSelecting { full_reading, .. } = self {
@@ -1511,9 +1488,9 @@ impl SessionState {
         false
     }
 
-    /// BlockSelecting: 次のブロックへ進む（Enter 押下時）。
-    /// 最終ブロックの場合は false を返す（呼び出し元は全確定処理を行う）。
-    pub fn block_selecting_advance(&mut self) -> bool {
+    /// BlockSelecting: フォーカスを次のブロックへ移す（→ 押下時）。
+    /// 最終ブロックで呼ぶと移動せず false を返す。
+    pub fn block_selecting_move_next(&mut self) -> bool {
         if let SessionState::BlockSelecting {
             blocks,
             current_index,
@@ -1527,45 +1504,16 @@ impl SessionState {
         false
     }
 
-    /// BlockSelecting: 現在ブロックのコミットテキスト（candidate + trailing_punct）を
-    /// `committed_prefix` に積算し、そのテキストを返す。
-    ///
-    /// Enter でブロックを1つずつ確定する際に呼ぶ。`advance()` の前に呼ぶこと。
-    pub fn block_selecting_commit_current(&mut self) -> Option<String> {
-        if let SessionState::BlockSelecting {
-            blocks,
-            current_index,
-            committed_prefix,
-            ..
-        } = self
+    /// BlockSelecting: フォーカスを前のブロックへ移す（← 押下時）。
+    /// 先頭ブロックで呼ぶと移動せず false を返す。
+    pub fn block_selecting_move_prev(&mut self) -> bool {
+        if let SessionState::BlockSelecting { current_index, .. } = self
+            && *current_index > 0
         {
-            let block = blocks.get(*current_index)?;
-            let cand = block.current_candidate().to_string();
-            let punct = block
-                .trailing_punct
-                .map(|c| c.to_string())
-                .unwrap_or_default();
-            let text = format!("{cand}{punct}");
-            committed_prefix.push_str(&text);
-            Some(text)
-        } else {
-            None
+            *current_index -= 1;
+            return true;
         }
-    }
-
-    /// BlockSelecting: 積算済みコミット済みテキスト（`committed_prefix`）を返す。
-    ///
-    /// 最終ブロック確定時に `block_selecting_commit_current()` を呼んだ後に参照すると
-    /// 全ブロックのテキストが得られる（学習・engine.commit 用）。
-    pub fn block_selecting_accumulated_text(&self) -> Option<String> {
-        if let SessionState::BlockSelecting {
-            committed_prefix, ..
-        } = self
-        {
-            Some(committed_prefix.clone())
-        } else {
-            None
-        }
+        false
     }
 
     // ── 共通 ────────────────────────────────────────────────────────────────
@@ -2469,6 +2417,71 @@ fn is_terminal_hwnd(hwnd_val: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn conv_block(reading: &str, candidate: &str, punct: Option<char>) -> ConversionBlock {
+        ConversionBlock {
+            reading: reading.to_string(),
+            trailing_punct: punct,
+            candidates: vec![candidate.to_string()],
+            selected: 0,
+        }
+    }
+
+    fn two_block_session() -> SessionState {
+        let mut sess = SessionState::Idle;
+        sess.set_block_selecting(
+            vec![
+                conv_block("いちどにできるときと", "一度にできる時と", Some('、')),
+                conv_block("さいごまで", "最後まで", None),
+            ],
+            "いちどにできるときと、さいごまで".to_string(),
+        );
+        sess
+    }
+
+    #[test]
+    fn block_selecting_focus_moves_both_ways_and_stops_at_ends() {
+        let mut sess = two_block_session();
+        // 先頭ブロックでは ← は動かない
+        assert!(!sess.block_selecting_move_prev());
+        assert_eq!(
+            sess.block_selecting_composition_parts(),
+            Some((
+                String::new(),
+                "一度にできる時と".to_string(),
+                "、最後まで".to_string()
+            ))
+        );
+        // → で 2 ブロック目へフォーカスが移り、手前のブロックは prefix になる
+        assert!(sess.block_selecting_move_next());
+        assert_eq!(
+            sess.block_selecting_composition_parts(),
+            Some((
+                "一度にできる時と、".to_string(),
+                "最後まで".to_string(),
+                String::new()
+            ))
+        );
+        // 最終ブロックでは → は動かない
+        assert!(!sess.block_selecting_move_next());
+        // ← で戻る
+        assert!(sess.block_selecting_move_prev());
+        assert_eq!(sess.block_selecting_index_of(), Some((0, 2)));
+    }
+
+    #[test]
+    fn block_selecting_full_text_is_independent_of_focus() {
+        // Enter は composition 全体を確定するので、どのブロックにフォーカスが
+        // あっても確定する文字列は変わらない。
+        let mut sess = two_block_session();
+        let expected = Some("一度にできる時と、最後まで".to_string());
+        assert_eq!(sess.block_selecting_full_text(), expected);
+        assert!(sess.block_selecting_move_next());
+        assert_eq!(sess.block_selecting_full_text(), expected);
+        // composition の表示（prefix + cand + remainder）とも一致する
+        let (prefix, cand, remainder) = sess.block_selecting_composition_parts().unwrap();
+        assert_eq!(Some(format!("{prefix}{cand}{remainder}")), expected);
+    }
 
     #[test]
     fn live_conversion_reading_ready_starts_at_min_chars() {

--- a/crates/rakukan-tsf/src/tsf/factory/edit_ops.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/edit_ops.rs
@@ -717,19 +717,59 @@ impl super::TextServiceFactory_Impl {
         Ok(true)
     }
 
-    /// Left: 選択文節を左へ移動する。
+    /// Left: BlockSelecting ではフォーカスを前のブロックへ移す。
+    /// それ以外の状態では消費するだけ（rakukan は preedit 内にキャレットを持たない）。
     pub(super) fn on_segment_move_left(
         &self,
-        _ctx: ITfContext,
-        _tid: u32,
-        _sink: ITfCompositionSink,
-        mut guard: crate::engine::state::EngineGuard,
+        ctx: ITfContext,
+        tid: u32,
+        sink: ITfCompositionSink,
+        guard: crate::engine::state::EngineGuard,
     ) -> Result<bool> {
-        let engine = match guard.as_mut() {
-            Some(e) => e,
+        self.on_block_focus_move(ctx, tid, sink, guard, false)
+    }
+
+    /// ← / → で BlockSelecting のフォーカスブロックを移動する。
+    ///
+    /// `current_index` を動かす経路はここだけ。Space / CandidateNext / CandidatePrev は
+    /// 現在ブロックの `selected` を回すだけなので、これが無いと 2 ブロック目以降は
+    /// 先頭候補で固定され、選び直せなくなる。
+    fn on_block_focus_move(
+        &self,
+        ctx: ITfContext,
+        tid: u32,
+        sink: ITfCompositionSink,
+        guard: crate::engine::state::EngineGuard,
+        forward: bool,
+    ) -> Result<bool> {
+        let has_pre = match guard.as_ref() {
+            Some(e) => !e.preedit_is_empty(),
             None => return Ok(false),
         };
-        Ok(!engine.preedit_is_empty())
+        drop(guard);
+        let mut sess = session_get()?;
+        if !sess.is_block_selecting() {
+            return Ok(has_pre);
+        }
+        let moved = if forward {
+            sess.block_selecting_move_next()
+        } else {
+            sess.block_selecting_move_prev()
+        };
+        if !moved {
+            // 端でこれ以上動けない場合もアプリへは渡さない（composition 中のため）。
+            return Ok(true);
+        }
+        let page_cands = sess.block_selecting_page_candidates();
+        let page_sel = sess.block_selecting_page_selected();
+        let (prefix, cand_text, remainder) =
+            sess.block_selecting_composition_parts().unwrap_or_default();
+        let caret = caret_rect_get();
+        drop(sess);
+        candidate_window::update_selection(page_sel, "");
+        candidate_window::show(&page_cands, page_sel, "", caret.left, caret.bottom);
+        update_composition_candidate_parts(ctx, tid, sink, prefix, cand_text, remainder)?;
+        Ok(true)
     }
 
     /// Shift+Left: 選択範囲を左側から縮めるのではなく、右端を左へ戻す。
@@ -849,26 +889,24 @@ impl super::TextServiceFactory_Impl {
         Ok(!engine.preedit_is_empty())
     }
 
-    /// Right: 選択文節を右へ移動する。
+    /// Right: BlockSelecting ではフォーカスを次のブロックへ移す。
+    /// それ以外の状態では消費するだけ（rakukan は preedit 内にキャレットを持たない）。
     pub(super) fn on_segment_move_right(
         &self,
-        _ctx: ITfContext,
-        _tid: u32,
-        _sink: ITfCompositionSink,
-        mut guard: crate::engine::state::EngineGuard,
+        ctx: ITfContext,
+        tid: u32,
+        sink: ITfCompositionSink,
+        guard: crate::engine::state::EngineGuard,
     ) -> Result<bool> {
-        let engine = match guard.as_mut() {
-            Some(e) => e,
-            None => return Ok(false),
-        };
-        Ok(!engine.preedit_is_empty())
+        self.on_block_focus_move(ctx, tid, sink, guard, true)
     }
 
     /// Home / End: 未確定文字列がある間はアプリへ渡さず IME 内で処理する（Issue #11）。
     ///
-    /// rakukan は preedit 内にキャレットを持たない（Left / Right も消費するだけ）ため、
-    /// Preedit / LiveConv / Waiting / Selecting / BlockSelecting では消費して何もしない
-    /// （BlockSelecting は確定済みブロックへ戻れないので先頭ブロックへの移動も定義しない）。
+    /// rakukan は preedit 内にキャレットを持たない（BlockSelecting を除き Left / Right も
+    /// 消費するだけ）ため、Preedit / LiveConv / Waiting / Selecting / BlockSelecting では
+    /// 消費して何もしない（BlockSelecting のブロック移動は ← / → に割り当ててあり、
+    /// Home / End で先頭 / 末尾ブロックへ飛ばすかは未定）。
     /// RangeSelect では選択範囲の右端を先頭（1 文字）/ 末尾（全体）へ移す。
     /// 未確定文字列が無ければ `false` を返してアプリへ渡す。
     pub(super) fn on_cursor_jump(

--- a/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
@@ -822,7 +822,7 @@ impl super::TextServiceFactory_Impl {
             let comp_parts: (String, String, String);
             {
                 let mut sess = session_get()?;
-                sess.set_block_selecting(blocks, full_reading, caret.left, caret.bottom);
+                sess.set_block_selecting(blocks, full_reading);
                 page_cands = sess.block_selecting_page_candidates();
                 page_sel = sess.block_selecting_page_selected();
                 comp_parts = sess.block_selecting_composition_parts().unwrap_or_default();
@@ -1535,56 +1535,38 @@ impl super::TextServiceFactory_Impl {
                 commit_then_start_composition(ctx, tid, sink, selected, preedit)?;
                 return Ok(true);
             }
-            // ── BlockSelecting（区読点分割変換）: Enter → 現在ブロック確定、次へ ──
+            // ── BlockSelecting（区読点分割変換）: Enter → 全ブロックまとめて確定 ──
+            //
+            // Enter は composition 全体を確定する（MS-IME / Google 日本語入力と同じ）。
+            //
+            // 以前は「現在ブロックだけ確定して次へ進む」実装だったため、読点を含む文を
+            // Space で変換すると必ずブロック数ぶんの Enter が要り、そのたびに断片が
+            // アプリへ書き込まれていた（ライブ変換のまま Enter なら一文が一度に入るのに、
+            // 途中で Space を挟んだ時だけ細切れになる）。
+            //
+            // 部分確定の経路が無くなったので composition には常に全ブロックが載っている
+            // （`update_composition_candidate_parts` の prefix ＝ current_index より前の
+            // ブロック）。`end_composition` にも全体を渡すこと。
             if sess.is_block_selecting() {
-                // advance() の前に現在ブロックのテキストを取得・積算する
-                let just_committed = sess.block_selecting_commit_current().unwrap_or_default();
-                let can_advance = sess.block_selecting_advance();
-                if can_advance {
-                    // まだ次のブロックがある:
-                    //   1. 確定したブロックをドキュメントへコミット（1 EditSession）
-                    //   2. 残りブロックで新しい composition を開始
-                    // NOTE: commit_then_start_composition + update_composition_candidate_parts の
-                    //       二段呼び出しは、二つ目のセッションが古い composition range に
-                    //       SetText を走らせてテキストを消す競合を起こす場合があるため、
-                    //       commit_then_start_composition 一発で完結させる。
-                    //       新 composition は uniform input underline で表示される。
-                    let page_cands = sess.block_selecting_page_candidates();
-                    let page_sel = sess.block_selecting_page_selected();
-                    // advance後の残りテキスト (prefix は無視して cand + rem のみ)
-                    let (_, new_cand, new_rem) =
-                        sess.block_selecting_composition_parts().unwrap_or_default();
-                    let (px, py) = sess.block_selecting_pos().unwrap_or_default();
-                    drop(sess);
-                    drop(guard);
-                    candidate_window::show(&page_cands, page_sel, "", px, py);
-                    // 確定済みブロックをコミットし、残りで新 composition 開始（1セッション）
-                    let new_full = format!("{new_cand}{new_rem}");
-                    commit_then_start_composition(ctx, tid, sink, just_committed, new_full)?;
-                } else {
-                    // 最終ブロック: commit_current で accumulated_text が完成している
-                    let full_text = sess.block_selecting_accumulated_text().unwrap_or_default();
-                    let full_reading = sess.block_selecting_full_reading().unwrap_or_default();
-                    sess.set_idle();
-                    drop(sess);
-                    candidate_window::hide();
-                    if crate::engine::state::is_auto_learn_enabled()
-                        && full_text != full_reading
-                        && !full_reading.is_empty()
-                    {
-                        engine.learn(&full_reading, &full_text);
-                    }
-                    engine.commit(&full_text);
-                    engine.reset_preedit();
-                    drop(guard);
-                    tracing::info!(
-                        "on_commit_raw[BlockSelecting]: commit last={:?} full={:?}",
-                        just_committed,
-                        full_text
-                    );
-                    // 最終ブロックは composition に残っているテキスト (just_committed) を確定
-                    end_composition(ctx, tid, just_committed)?;
+                let full_text = sess.block_selecting_full_text().unwrap_or_default();
+                let full_reading = sess.block_selecting_full_reading().unwrap_or_default();
+                sess.set_idle();
+                drop(sess);
+                candidate_window::hide();
+                if crate::engine::state::is_auto_learn_enabled()
+                    && full_text != full_reading
+                    && !full_reading.is_empty()
+                {
+                    engine.learn(&full_reading, &full_text);
                 }
+                engine.commit(&full_text);
+                engine.reset_preedit();
+                drop(guard);
+                tracing::info!("on_commit_raw[BlockSelecting]: commit full={:?}", full_text);
+                diag::event(DiagEvent::CommitRaw {
+                    preedit: full_text.clone(),
+                });
+                end_composition(ctx, tid, full_text)?;
                 return Ok(true);
             }
             // ── Waiting（⏳変換中）: ひらがなのままコミット ──


### PR DESCRIPTION
Issue #18 の C（Enter / 確定まわり）の 3 件目です。現行 main（`9ac120f`）基準で、#19 / #20 とは独立です。

## 症状

**読点を含む文を Space で変換すると、Enter がブロック数ぶん必要で、そのたびに断片がアプリへ書き込まれます。** ライブ変換のまま Enter を押せば一文が一度に入るので、**途中で Space を挟んだ時だけ細切れになります。** ユーザーからは「確定が細切れになる時とならない時がある」としか見えません。

実害の記録（2026-09-01、`rakukan.log`）:

```
on_commit_raw[BlockSelecting]: commit last="分かれる"
    full="一度にできる時と、へんに細切れになる時に分かれる"
```

`last`（最終ブロック）と `full` が食い違っている ＝ **「一度にできる時と、」が別の書き込みで先に入っています。** 中間ブロックの確定はログを出さないので、行数を数えても気付けませんでした。

## 変更

`on_commit_raw` の BlockSelecting 分岐を、**composition 全体を一度に確定する**形にしました（MS-IME / Google 日本語入力と同じ挙動）。

- 学習・`engine.commit()`・`end_composition` のいずれにも `block_selecting_full_text()` を渡します。部分確定の経路が無くなったことで composition には常に全ブロックが載る（`update_composition_candidate_parts` の prefix ＝ `current_index` より前のブロック）ので、composition の一部だけを渡すと先頭ブロックがドキュメントから消えます。
- ログを `last=` から `full=` に変えました。あわせて他の確定分岐と同じ `DiagEvent::CommitRaw` を出すようにしています（この分岐だけ出ていませんでした）。

## ← / → でブロックを移動できるようにしました

`current_index` を動かす経路が Enter しか無かったため、**そのままだと 2 ブロック目以降が先頭候補で固定され、選び直せなくなります**（Space / CandidateNext / CandidatePrev は現在ブロックの `selected` を回すだけで `current_index` は動かしません）。← / → にブロック移動を割り当てました。

- `on_segment_move_left` / `on_segment_move_right` に BlockSelecting の分岐を足し、共通処理 `on_block_focus_move()` で `current_index` を ±1 して composition と候補ウィンドウを張り直します。中身は既存の候補サイクル（`on_candidate_cycle` の BlockSelecting 分岐）と同じ並びです。
- `block_selecting_advance()` を **`block_selecting_move_next()`** にリネームし、← 用の **`block_selecting_move_prev()`** を新設しました。
- 端（先頭で ← / 最終で →）では移動せず、消費だけします（composition 中にアプリへ透過させないため）。

部分確定用の `block_selecting_commit_current()` / `block_selecting_accumulated_text()` / `block_selecting_pos()` と、フィールドの `committed_prefix` / `pos_x` / `pos_y` は削除しました。`pos_x` / `pos_y` は `set_block_selecting()` の引数からも外しています（候補ウィンドウの位置は同じ場所で `caret_rect_get()` から取っているので表示は変わりません）。

doc コメントは `SessionState::BlockSelecting` の遷移表・`block_selecting_composition_parts()` の prefix の説明・`on_cursor_jump` の 3 か所を新しい挙動に合わせました。Home / End は据え置き（消費して何もしない）です。

## 確認

- `cargo test -p rakukan-tsf --release --lib` — 95 passed / 0 failed（← / → のブロック移動と、確定文字列が `current_index` に依らないことのテストを 2 件追加）
- `cargo clippy -p rakukan-tsf --release --all-targets -- -D warnings` — 警告なし
- `cargo fmt --all -- --check` — 差分なし
- **実機は未確認です。** ← / → の操作感と、移動後の Enter が全体を 1 回で確定することは DLL 差し替え後に確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
