### PR TITLE
docs(tsf): キャレット矩形更新のコメントを、この repo に存在する経路で書き直す

### DIFF
--- a/crates/rakukan-tsf/src/tsf/factory/on_compose.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_compose.rs
@@ -219,11 +219,16 @@ pub(super) fn update_composition(
         }
 
         // 打鍵のたびにキャレット矩形を更新する。
-        // 予測ウィンドウ（`suggestion::show`）と候補ウィンドウは `caret_rect_get()` を
-        // 見るが、CARET_RECT を更新するのは Space 押下（`update_caret_rect`）と
-        // `commit_then_start_composition` だけだった。そのため、プロセス内で
-        // 一度も変換・確定を挟んでいない入力では初期値 (0,0,0,0) のままになり、
-        // 予測ウィンドウがプライマリモニタの左上に出てしまう。
+        //
+        // 候補ウィンドウの表示位置は `caret_rect_get()` を読むが、CARET_RECT を
+        // 更新するのは Space 押下時の `update_caret_rect()` と
+        // `commit_then_start_composition()` だけだった。`update_caret_rect()` は
+        // 非同期の EditSession を投げるだけなので、同じ Space の処理内で
+        // `caret_rect_get()` を読む側はまだ更新前の値を見る。プロセス内で最初の
+        // 変換ではそれが初期値 (0,0,0,0) にあたり、候補ウィンドウがプライマリ
+        // モニタの左上に出てしまう。
+        //
+        // ここで更新しておけば、Space が来る前に必ず正しい矩形が入っている。
         if let Ok(view) = ctx.GetActiveView() {
             use windows::Win32::Foundation::RECT;
             let mut rect = RECT::default();


### PR DESCRIPTION
**#17 で入れたコメントの訂正です。コメントのみの変更で、動作は変わりません。**

#17 の説明とコード内コメントで、根拠として**予測ウィンドウ（`suggestion::show`）**を挙げていました。**これはこちらのフォークにしか無いモジュールで、このリポジトリには存在しません。** 手元の統合ブランチの症状をそのまま持ち込んでしまったもので、確認不足でした。すみません。

## このリポジトリでの実際の症状

修正自体は必要でしたが、出方が違います。`caret_rect_get()` を読むのは**候補ウィンドウだけ**です。

`on_convert()` は先頭で `update_caret_rect()` を呼びますが、**これは非同期の `RequestEditSession` を投げるだけ**なので、同じ Space の処理内で後から `caret_rect_get()`（`on_convert.rs` の 293 行目など）を読む側は、まだ更新前の値を見ます。したがって **プロセス内で最初の変換では初期値 `(0,0,0,0)` が読まれ、候補ウィンドウがプライマリモニタの左上に出ます。** 2 回目以降は前回の値が残っているので正しい位置になります。

`commit_then_start_composition()` に既にあるコメント（「`RequestEditSession` は非同期のため、次のキー入力より先にここで更新しないと Space キーハンドラが `caret_rect_get()` を読む時点でまだ旧値になってしまう」）が指しているのと同じ問題で、**Space より前に composition が張られる経路（`update_composition`）にはその手当てが無かった**、というのが #17 の内容になります。

コメントをこの内容に書き換えました。**動作を変える必要は無いと考えていますが、判断が違えば revert でも構いません。**

## 確認

- `cargo fmt --all -- --check` — 差分なし
- コメントのみの変更なので clippy / test は #17 時点から変わりません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
