### PR TITLE
fix(tsf): IME OFF でも候補選択中の表示文字列を確定し、候補ウィンドウを閉じる

### DIFF
--- a/crates/rakukan-tsf/src/tsf/factory/edit_ops.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/edit_ops.rs
@@ -384,7 +384,9 @@ impl super::TextServiceFactory_Impl {
         Ok(true)
     }
 
-    pub(super) fn on_ime_toggle(&self, ctx: ITfContext, tid: u32) -> Result<bool> {
+    /// IME の ON/OFF を切り替える前に、画面に出ている合成文字列を確定して
+    /// 候補ウィンドウを閉じる（ImeToggle / ImeOff 共通）。
+    fn commit_composition_before_mode_switch(&self, ctx: &ITfContext, tid: u32) -> Result<()> {
         {
             let mut guard = engine_try_get_or_create()?;
             if let Some(engine) = guard.as_mut() {
@@ -449,6 +451,11 @@ impl super::TextServiceFactory_Impl {
                 }
             }
         }
+        Ok(())
+    }
+
+    pub(super) fn on_ime_toggle(&self, ctx: ITfContext, tid: u32) -> Result<bool> {
+        self.commit_composition_before_mode_switch(&ctx, tid)?;
         let (from, to, now_open) = if let Ok(mut st) = crate::engine::state::ime_state_get() {
             use crate::engine::input_mode::InputMode;
             let was_alpha = st.input_mode == InputMode::Alphanumeric;
@@ -490,36 +497,10 @@ impl super::TextServiceFactory_Impl {
     }
 
     pub(super) fn on_ime_off(&self, ctx: ITfContext, tid: u32) -> Result<bool> {
-        {
-            let mut guard = engine_try_get_or_create()?;
-            if let Some(engine) = guard.as_mut() {
-                // LiveConv 中は preview をコミットしてから IME をオフにする
-                let commit_text = {
-                    let sess = session_get();
-                    if let Ok(s) = &sess {
-                        if s.is_live_conv() {
-                            s.live_conv_parts().map(|(_, p)| p.to_string())
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                };
-                let preedit = commit_text.unwrap_or_else(|| engine.preedit_display());
-                if !preedit.is_empty() {
-                    engine.bg_reclaim();
-                    engine.commit(&preedit.clone());
-                    engine.reset_preedit();
-                    drop(guard);
-                    if let Ok(mut sess) = session_get() {
-                        sess.set_idle();
-                    }
-                    candidate_window::stop_live_timer();
-                    end_composition(ctx.clone(), tid, preedit)?;
-                }
-            }
-        }
+        // 候補選択中でも「画面に出ている合成文字列」を確定し、候補ウィンドウを
+        // 閉じる（従来は engine の読みを確定していたため、選んだ候補ではなく
+        // 読みが入り、候補ウィンドウも残っていた）。
+        self.commit_composition_before_mode_switch(&ctx, tid)?;
         if let Ok(mut st) = crate::engine::state::ime_state_get() {
             let from = format!("{:?}", st.input_mode);
             st.set_mode(crate::engine::input_mode::InputMode::Alphanumeric);


### PR DESCRIPTION
Issue #18 の C（Enter / 確定まわり）の 5 件目です。

> ⚠ **この PR は #22 の上に積んでいます。** #22 で入れた「画面に出ている合成文字列を確定する」処理をそのまま共通化するので、分離できませんでした。**#22 をマージしたあとにご覧ください**（マージ後はこの PR の差分だけになります）。レビュー対象は `44c1d96` の 1 コミットです。

## 症状

**候補選択中に IME を OFF にすると、選んだ候補ではなく読みが入り、候補ウィンドウが残ります。**

## 原因

`on_ime_off` は LiveConv 以外では `engine.preedit_display()`（＝読み）を確定していました。#22 で `on_ime_toggle`（半角/全角キー）側は直しましたが、**`on_ime_off` は同じコードの古いコピーのままでした。**

## 変更

#22 で `on_ime_toggle` に入れた確定処理を `commit_composition_before_mode_switch()` として切り出し、**`ImeToggle` / `ImeOff` の両方から呼びます。**

- `on_ime_off` の挙動が `on_ime_toggle` と同じになります（BlockSelecting / Selecting / RangeSelect / Waiting のいずれでも画面に出ている文字列を確定し、いずれも取れなければ従来どおり `engine.preedit_display()` へ落ちる）。
- 候補ウィンドウの `hide()` も共通処理に入っているので、**IME OFF で窓が残らなくなります。**
- 差分は実質「同じ処理の 2 個目のコピーを消して 1 個目を呼ぶ」だけで、新しい分岐は増えていません。

## 確認

- `cargo test -p rakukan-tsf --release` — 93 passed / 0 failed
- `cargo clippy -p rakukan-tsf --release --all-targets -- -D warnings` — 警告なし
- `cargo fmt --all -- --check` — 差分なし

**元のコミットには予測ウィンドウを閉じる 1 行（`suggestion::clear()`）も入っていましたが、`suggestion` モジュールはこちらのフォークにしか無いので外しました**（#23 で訂正したのと同じ経緯です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
