### PR TITLE
fix(tsf): KEYBOARD_OPENCLOSE コンパートメントの外部変更に追随する

### DIFF
--- a/crates/rakukan-tsf/src/tsf/candidate_window.rs
+++ b/crates/rakukan-tsf/src/tsf/candidate_window.rs
@@ -203,6 +203,9 @@ struct FocusChange {
 
 /// カスタムメッセージ: OnSetFocus を msctf コールバック外で実行する。
 const WM_APP_FOCUS_CHANGED: u32 = WM_APP + 1;
+/// KEYBOARD_OPENCLOSE コンパートメントが外部（アプリの ImmSetOpenStatus /
+/// CtfImm）から変えられたときの遅延処理
+const WM_APP_OPENCLOSE_CHANGED: u32 = WM_APP + 2;
 
 #[derive(Default, Clone)]
 struct CandData {
@@ -298,6 +301,11 @@ unsafe extern "system" fn wnd_proc(
         // OnSetFocus 遅延処理: msctf コールバックから抜けた後にここで処理する
         m if m == WM_APP_FOCUS_CHANGED => {
             handle_pending_focus_changes();
+            LRESULT(0)
+        }
+        // ITfCompartmentEventSink::OnChange 遅延処理
+        m if m == WM_APP_OPENCLOSE_CHANGED => {
+            process_openclose_change();
             LRESULT(0)
         }
         _ => DefWindowProcW(hwnd, msg, wparam, lparam),
@@ -933,6 +941,65 @@ pub fn invalidate_live_context_for_dm(dm_ptr: usize) {
     if matched {
         tracing::debug!("[Live] invalidate_live_context_for_dm: marked stale dm={dm_ptr:#x}");
     }
+}
+
+/// `ITfCompartmentEventSink::OnChange`（KEYBOARD_OPENCLOSE）から呼ばれる。
+/// msctf のコールバック内では何もせず、WM_APP_OPENCLOSE_CHANGED を PostMessage
+/// して抜ける（OnSetFocus と同じ理由）。
+pub fn post_openclose_changed() {
+    let hwnd = ensure_hwnd();
+    if is_valid(hwnd) {
+        unsafe {
+            let _ = PostMessageW(hwnd, WM_APP_OPENCLOSE_CHANGED, WPARAM(0), LPARAM(0));
+        }
+    }
+}
+
+/// コンパートメントの現在値（開＝1）を rakukan の入力モードに反映する。
+///
+/// クリスタ（IMM アプリ）は文字編集に入ると `ImmSetOpenStatus(TRUE)`、Esc で
+/// `FALSE` を呼び、CtfImm がそれを KEYBOARD_OPENCLOSE に書く。AHK 等の
+/// `IMC_SETOPENSTATUS` も同じ経路。rakukan 自身の切替も同じコンパートメントに
+/// 書くが（`set_open_close`）、そのときは値とモードが一致するので何もしない＝
+/// ループしない。
+fn process_openclose_change() {
+    use crate::engine::input_mode::InputMode;
+    // 溜まっているフォーカス変化を先に消化する。フォーカス移動（OnSetFocus）と
+    // ImmSetOpenStatus は同じスレッドのキューに積まれ、どちらが先に処理されるかは
+    // アプリ次第。OPENCLOSE が先に走ると、まだ更新されていない TL_CURRENT_DM に
+    // モードを記憶してしまい、続く process_focus_change が前の DM の記憶モードで
+    // 上書きする（クリスタでテキストツールに入っても直接入力のまま戻る）。
+    handle_pending_focus_changes();
+    let tm_opt = TL_THREAD_MGR.with(|c| c.borrow().clone());
+    let Some(tm) = tm_opt else {
+        return;
+    };
+    let open = crate::tsf::language_bar::get_open_close(&tm);
+    let Ok(mut st) = crate::engine::state::ime_state_get() else {
+        tracing::warn!("compartment OPENCLOSE changed but ime_state is locked; ignored");
+        return;
+    };
+    let currently_open = st.input_mode != InputMode::Alphanumeric;
+    if open == currently_open {
+        return;
+    }
+    let new_mode = if open {
+        InputMode::Hiragana
+    } else {
+        InputMode::Alphanumeric
+    };
+    tracing::info!(
+        "compartment OPENCLOSE changed externally: open={} → mode {:?} → {:?}",
+        open,
+        st.input_mode,
+        new_mode
+    );
+    st.set_mode(new_mode);
+    drop(st);
+    hide();
+    stop_live_timer();
+    crate::engine::state::langbar_update_set();
+    crate::tsf::tray_ipc::publish(open, new_mode);
 }
 
 /// OnSetFocus から呼ばれる。イベントをキューに積み、WM_APP_FOCUS_CHANGED を

--- a/crates/rakukan-tsf/src/tsf/factory.rs
+++ b/crates/rakukan-tsf/src/tsf/factory.rs
@@ -42,15 +42,18 @@ use windows::{
         UI::{
             Input::KeyboardAndMouse::GetKeyState,
             TextServices::{
-                CLSID_TF_CategoryMgr, IEnumTfDisplayAttributeInfo, ITfCategoryMgr, ITfComposition,
-                ITfCompositionSink, ITfCompositionSink_Impl, ITfContext, ITfDisplayAttributeInfo,
-                ITfDisplayAttributeProvider, ITfDisplayAttributeProvider_Impl, ITfDocumentMgr,
-                ITfKeyEventSink, ITfKeyEventSink_Impl, ITfKeystrokeMgr, ITfLangBarItem,
-                ITfLangBarItem_Impl, ITfLangBarItemButton, ITfLangBarItemButton_Impl,
-                ITfLangBarItemSink, ITfMenu, ITfSource, ITfSource_Impl, ITfTextInputProcessor,
-                ITfTextInputProcessor_Impl, ITfThreadFocusSink, ITfThreadFocusSink_Impl,
-                ITfThreadMgr, ITfThreadMgrEventSink, ITfThreadMgrEventSink_Impl, TF_ES_READWRITE,
-                TF_LANGBARITEMINFO, TF_LBMENUF_RADIOCHECKED, TF_LBMENUF_SEPARATOR, TfLBIClick,
+                CLSID_TF_CategoryMgr, GUID_COMPARTMENT_KEYBOARD_OPENCLOSE,
+                IEnumTfDisplayAttributeInfo, ITfCategoryMgr, ITfCompartment,
+                ITfCompartmentEventSink, ITfCompartmentEventSink_Impl, ITfCompartmentMgr,
+                ITfComposition, ITfCompositionSink, ITfCompositionSink_Impl, ITfContext,
+                ITfDisplayAttributeInfo, ITfDisplayAttributeProvider,
+                ITfDisplayAttributeProvider_Impl, ITfDocumentMgr, ITfKeyEventSink,
+                ITfKeyEventSink_Impl, ITfKeystrokeMgr, ITfLangBarItem, ITfLangBarItem_Impl,
+                ITfLangBarItemButton, ITfLangBarItemButton_Impl, ITfLangBarItemSink, ITfMenu,
+                ITfSource, ITfSource_Impl, ITfTextInputProcessor, ITfTextInputProcessor_Impl,
+                ITfThreadFocusSink, ITfThreadFocusSink_Impl, ITfThreadMgr, ITfThreadMgrEventSink,
+                ITfThreadMgrEventSink_Impl, TF_ES_READWRITE, TF_LANGBARITEMINFO,
+                TF_LBMENUF_RADIOCHECKED, TF_LBMENUF_SEPARATOR, TfLBIClick,
             },
             WindowsAndMessaging::{
                 AppendMenuW, CreatePopupMenu, DestroyMenu, GA_ROOT, GetAncestor,
@@ -321,6 +324,10 @@ pub struct TextServiceState {
     pub threadmgr_cookie: u32,
     /// ITfThreadFocusSink の登録クッキー（Deactivate で解除）
     pub threadfocus_cookie: u32,
+    /// KEYBOARD_OPENCLOSE コンパートメントの ITfCompartmentEventSink 登録
+    /// （Deactivate で解除。解除には登録先のコンパートメントが要る）
+    pub openclose_cookie: u32,
+    pub openclose_comp: Option<ITfCompartment>,
 }
 
 // Safety: TSF は STA。RefCell + COM オブジェクトを持つが
@@ -340,6 +347,7 @@ unsafe impl Send for TextServiceState {}
     ITfSource,
     ITfThreadMgrEventSink,
     ITfThreadFocusSink,
+    ITfCompartmentEventSink,
     ITfDisplayAttributeProvider
 )]
 pub struct TextServiceFactory {
@@ -512,6 +520,32 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
             }
         }
 
+        // KEYBOARD_OPENCLOSE コンパートメントの変更を受け取る。IMM アプリ
+        // （クリスタ等）の ImmSetOpenStatus や AHK の IMC_SETOPENSTATUS は
+        // CtfImm 経由でここに来る。処理は candidate_window の遅延ハンドラで行う。
+        unsafe {
+            let registered = (|| -> windows::core::Result<(u32, ITfCompartment)> {
+                let mgr: ITfCompartmentMgr = tm.cast()?;
+                let comp = mgr.GetCompartment(&GUID_COMPARTMENT_KEYBOARD_OPENCLOSE)?;
+                let src: ITfSource = comp.cast()?;
+                let sink: ITfCompartmentEventSink = self.cast()?;
+                let unk: IUnknown = sink.cast()?;
+                let cookie = src.AdviseSink(&ITfCompartmentEventSink::IID, &unk)?;
+                Ok((cookie, comp))
+            })();
+            match registered {
+                Ok((cookie, comp)) => {
+                    if let Ok(mut inner) = self.inner.try_borrow_mut() {
+                        inner.openclose_cookie = cookie;
+                        inner.openclose_comp = Some(comp);
+                    }
+                    tracing::debug!(
+                        "ITfCompartmentEventSink(OPENCLOSE) registered cookie={cookie}"
+                    );
+                }
+                Err(e) => tracing::warn!("AdviseSink(CompartmentEventSink) failed: {e}"),
+            }
+        }
         diag::event(DiagEvent::Activate { tid });
         tracing::info!("rakukan Activate client_id={tid}");
 
@@ -604,7 +638,21 @@ impl ITfTextInputProcessor_Impl for TextServiceFactory_Impl {
                     let _ = src.UnadviseSink(inner.threadfocus_cookie);
                     tracing::debug!("ITfThreadFocusSink unregistered");
                 }
+                // ITfCompartmentEventSink 登録解除（inner は不変借用なので値だけ読む）
+                if inner.openclose_cookie != 0
+                    && let Some(comp) = inner.openclose_comp.as_ref()
+                    && let Ok(src) = comp.cast::<ITfSource>()
+                {
+                    let _ = src.UnadviseSink(inner.openclose_cookie);
+                    tracing::debug!("ITfCompartmentEventSink unregistered");
+                }
             }
+        }
+        // 解除したコンパートメントの参照は落とす（Activate で登録し直される）。
+        drop(inner);
+        if let Ok(mut inner) = self.inner.try_borrow_mut() {
+            inner.openclose_cookie = 0;
+            inner.openclose_comp = None;
         }
         let _ = composition_set(None);
         if let Ok(mut g) = engine_get()
@@ -1390,6 +1438,16 @@ impl ITfThreadMgrEventSink_Impl for TextServiceFactory_Impl {
 // フォーカス遷移で発火する。ITfThreadMgrEventSink::OnSetFocus は TSF 対応
 // アプリ間でしか呼ばれないため、非対応アプリへ抜けたときの候補ウィンドウ
 // 残留を防ぐためにこちらも必要。
+
+impl ITfCompartmentEventSink_Impl for TextServiceFactory_Impl {
+    fn OnChange(&self, rguid: *const GUID) -> windows::core::Result<()> {
+        // msctf のコールバック内。ここで msctf に再入しない（OnSetFocus と同じ方針）。
+        if !rguid.is_null() && unsafe { *rguid } == GUID_COMPARTMENT_KEYBOARD_OPENCLOSE {
+            candidate_window::post_openclose_changed();
+        }
+        Ok(())
+    }
+}
 
 impl ITfThreadFocusSink_Impl for TextServiceFactory_Impl {
     fn OnSetThreadFocus(&self) -> windows::core::Result<()> {


### PR DESCRIPTION
Issue #18 の H から切り離した「`KEYBOARD_OPENCLOSE` コンパートメントの外部変更に追随する」です。**不具合修正として扱ってよいとのことでしたので H 本体（`text_field_mode`）とは分け、単独で出します。** 現行 main（`9ac120f`）基準で、他の PR とは独立です。

## 症状

**アプリ側が IME を開閉しても rakukan の入力モードが追随せず、表示と実際の入力が食い違います。**

一番分かりやすいのは CLIP STUDIO PAINT で、**テキストツールで文字編集に入っても直接入力のまま**になります。クリスタは文字編集の開始で `ImmSetOpenStatus(TRUE)`、Esc で `FALSE` を呼びます。AHK 等から `IMC_SETOPENSTATUS` を送った場合も同じです。

## 原因

これらはいずれも CtfImm 経由で `GUID_COMPARTMENT_KEYBOARD_OPENCLOSE` に書かれますが、**rakukan はこのコンパートメントを購読していませんでした**（書く側だけ `language_bar::set_open_close()` で実装されています）。

## 変更

- `Activate` で `ITfCompartmentEventSink` を `KEYBOARD_OPENCLOSE` へ `AdviseSink` し、`Deactivate` で `UnadviseSink` します。**解除には登録先のコンパートメントが要るので、cookie と一緒に `TextServiceState` へ持たせています。**
- `OnChange` は msctf のコールバック内なので、**`WM_APP_OPENCLOSE_CHANGED` を `PostMessage` するだけで抜けます。** 実処理は候補ウィンドウのメッセージループ側で行います（`OnSetFocus` と同じ方針です）。
- 実処理は「開＝ひらがな / 閉＝直接入力」に切り替え、候補ウィンドウを閉じ、ランゲージバーとトレイへ反映します。

## ループしないこと

rakukan 自身の切り替え（`set_open_close()`）も同じコンパートメントに書くので `OnChange` は飛んできますが、**そのときは既にコンパートメントの値と入力モードが一致しているので、`process_openclose_change()` は先頭で return します。** 自分の書き込みで再入することはありません。

## 確認

- `cargo test -p rakukan-tsf --release` — 93 passed / 0 failed
- `cargo clippy -p rakukan-tsf --release --all-targets -- -D warnings` — 警告なし
- `cargo fmt --all -- --check` — 差分なし

**実機での確認は、クリスタのテキストツールに入って直接日本語が打てるか（従来は一度半角/全角キーを押す必要がありました）が一番早いです。**

なお元のコミットは `TextServiceState` に手書きの `impl Default` がある前提でしたが、現行 main は `#[derive(Default)]` なので**そのまま追加フィールドを載せる形にしています。** `Deactivate` の解除処理も let-chain へ畳んであります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
