### PR TITLE
fix(engine): ひらがなモードで打った英単語が後ろの日本語ごと壊れるのを直す

### DIFF
--- a/crates/rakukan-engine/src/conv_cache.rs
+++ b/crates/rakukan-engine/src/conv_cache.rs
@@ -42,7 +42,13 @@ use crate::{DigitCandidateKind, default_digit_candidates_order};
 
 /// ワーカーへの変換リクエスト（single-slot 上書き式キュー）
 struct Request {
+    /// キャッシュのキー。TSF 側が持つ読み（`hiragana_buf`）と一致させる。
     hiragana: String,
+    /// 変換器へ実際に渡す読み。`hiragana` と同じこともあれば、先頭の英単語を
+    /// 打鍵どおりに復元した形（`せえdれあmのぺーす` → `seedreamのぺーす`）の
+    /// こともある。キーと分けているのは、呼び出し側が結果を引くときに使うのは
+    /// あくまで打鍵そのままの読みだから。
+    conv_reading: String,
     committed: String,
     converter: KanaKanjiConverter,
     n: usize,
@@ -135,6 +141,7 @@ fn worker_loop(cache: Arc<Cache>) {
         };
 
         let key = req.hiragana.clone();
+        let conv_reading = req.conv_reading.clone();
         let committed = req.committed.clone();
         let n = req.n;
         let digit_candidates_order = req.digit_candidates_order.clone();
@@ -147,7 +154,7 @@ fn worker_loop(cache: Arc<Cache>) {
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 crate::digits::convert_with_digit_protection(
                     &converter,
-                    &key,
+                    &conv_reading,
                     &committed,
                     n,
                     &digit_candidates_order,
@@ -201,8 +208,12 @@ fn worker_loop(cache: Arc<Cache>) {
 /// # 戻り値
 /// - `None`       = ワーカーに渡した（converter の所有権はキャッシュへ）
 /// - `Some(conv)` = 渡せなかった（同一キー実行中 or lock 取得失敗）
+// 変換の入力一式をそのまま受け取る。まとめる構造体を作っても Request と
+// 二重になるだけなので、引数の多さは許容する。
+#[allow(clippy::too_many_arguments)]
 pub fn start(
     hiragana: String,
+    conv_reading: String,
     committed: String,
     converter: KanaKanjiConverter,
     n: usize,
@@ -234,6 +245,7 @@ pub fn start(
 
     inner.pending = Some(Request {
         hiragana,
+        conv_reading,
         committed,
         converter,
         n,

--- a/crates/rakukan-engine/src/latin_run.rs
+++ b/crates/rakukan-engine/src/latin_run.rs
@@ -1,0 +1,202 @@
+//! 先頭ラテン語ランの復元
+//!
+//! ひらがなモードのまま英単語を打つと、読みはローマ字がかなに潰れた姿になる。
+//! 「seedream」なら `せえdれあm`（トライで解決できなかった子音だけが素の ASCII
+//! として残る）。この読みをそのまま [`crate::digits`] のリテラル保護レイヤーへ
+//! 渡すと、素の `d` / `m` だけがアルファベット run とみなされ、
+//! `せえ` / `れあ` / 後続の日本語が別々に LLM へ渡る。結果は
+//! `せえdレアmのぺーす` のような読めない文字列になる（2026-09-01 に実害）。
+//!
+//! ここでは打鍵ログ（[`crate::Engine::romaji_log_str`]）と読みを突き合わせ、
+//! **読みの先頭にあるラテン語ランを打鍵どおりのラテン文字へ戻した読み**を作る。
+//! `せえdれあmのぺーすはどう` → `seedreamのぺーすはどう`。
+//! これを変換器へ渡せば、既存のリテラル保護レイヤーが
+//! `Alpha("seedream")` ＋ `Kana("のぺーすはどう")` に分割し、LLM は日本語部分
+//! だけを見る（→ `seedreamのペースはどう`）。
+//!
+//! # 扱える形が限られる理由
+//! 素の ASCII は「ローマ字がかなに潰れきらなかった位置」を示すだけで、英単語の
+//! 左右の端そのものは指さない。かなは全てローマ字由来なので、境界の手掛かりは
+//! 打鍵ログにも存在しない。誤った位置で切ると日本語側を壊すため、両端が
+//! 決まる形だけを扱う:
+//!
+//! - 左端は「読みの先頭」に限る。途中に出る英単語（`これはseedreamです`）は
+//!   どこから始まるか決められない
+//! - 右端は「素の ASCII の直後が助詞」の場合に限る。`seedream` は末尾が `m` で
+//!   止まるので `のぺーすはどう` との境目が読める。`claude`（読み `cぁうで`）は
+//!   素の ASCII が先頭の `c` しか無く右端が決まらないので対象外
+//!
+//! # 全体がラテン文字の場合は対象外
+//! 後続にかなが無い読みは、この関数の目的である「英単語と日本語の境目を
+//! 読めるようにする」対象ではないので `None` を返す。
+
+use crate::romaji::RomajiConverter;
+
+/// 英単語の直後に来る助詞。読みの右端を決める唯一の手掛かりに使う。
+///
+/// 素の ASCII は「ローマ字がかなに潰れきらなかった位置」を示すだけで、英単語が
+/// どこで終わるかまでは決めない。`seedream` は末尾が `m` で止まるので右端が
+/// 分かるが、`google`（読み `ごおgぇ`）は末尾の `ぇ` まで英単語なのに素の
+/// ASCII は途中の `g` が最後になる。そこで切ると `googlれ` に化ける。
+///
+/// 素の ASCII の直後が助詞なら、そこが英単語の切れ目だと言い切ってよい
+/// （`seedream` ＋ `のぺーすはどう`）。助詞でなければ切らない。
+fn is_boundary_particle(c: char) -> bool {
+    matches!(
+        c,
+        'の' | 'を' | 'は' | 'が' | 'に' | 'で' | 'と' | 'も' | 'や' | 'へ'
+    )
+}
+
+/// 打鍵ログを [`crate::Engine::push_char`] と同じ手順で流し直し、
+/// 「ローマ字 n 文字まで ↔ かな m 文字まで」の境界一覧を返す。
+///
+/// 各要素は「未確定バッファを含まない」位置。`seedream` の `m` は次の `n` を
+/// 打った時点で初めて素の `m` として確定するが、境界としては `m` まで＝
+/// ローマ字 8 文字と記録する。ここで `n` まで含めてしまうと復元結果が
+/// `seedreamn` になる。
+fn boundaries(romaji: &str) -> Vec<(usize, usize)> {
+    let mut conv = RomajiConverter::new();
+    let mut pending_len = 0usize;
+    let mut kana_len = 0usize;
+    let mut marks = Vec::new();
+    for (i, c) in romaji.chars().enumerate() {
+        pending_len += 1;
+        let prev_output_len = conv.output().len();
+        let _ = conv.push(c);
+        let added_kana = conv.output()[prev_output_len..].chars().count();
+        let buffered = conv.buffer().chars().count();
+        if pending_len < buffered {
+            // 想定外（ログとコンバータがずれた）。以降の対応は信用できない。
+            return Vec::new();
+        }
+        let consumed = pending_len - buffered;
+        if consumed > 0 {
+            pending_len = buffered;
+            kana_len += added_kana;
+            marks.push((i + 1 - buffered, kana_len));
+        }
+    }
+    marks
+}
+
+/// 打鍵ログ全体をかなへ復元する（末尾の未確定バッファも flush する）。
+fn replay(romaji: &str) -> String {
+    let mut conv = RomajiConverter::new();
+    let mut out = String::new();
+    for c in romaji.chars() {
+        let prev = conv.output().len();
+        let _ = conv.push(c);
+        out.push_str(&conv.output()[prev..]);
+    }
+    out.push_str(&conv.flush());
+    out
+}
+
+/// 読みの先頭ラテン語ランを打鍵どおりのラテン文字へ戻した読みを返す。
+///
+/// `romaji` は [`crate::Engine::romaji_log_str`]（未確定バッファを含まない）、
+/// `hiragana` は `hiragana_buf` を渡す。復元できない場合は `None`。
+pub fn normalize_leading_latin(romaji: &str, hiragana: &str) -> Option<String> {
+    if romaji.is_empty() || hiragana.is_empty() {
+        return None;
+    }
+    let kana: Vec<char> = hiragana.chars().collect();
+    // 読みに素の ASCII 英字が残っている＝ローマ字がかなに変換しきれていない。
+    // 普通の日本語の読みはここで弾かれる。
+    let last_ascii = kana.iter().rposition(|c| c.is_ascii_alphabetic())?;
+    let split = last_ascii + 1;
+    if split >= kana.len() {
+        // 後続のかなが無い＝読み全体が英単語。分ける境目が無いので何もしない。
+        return None;
+    }
+    // 素の ASCII の直後が助詞のときだけ「ここで英単語が終わった」と判断する。
+    // 助詞以外が続くなら、英単語がまだ続いているのか日本語が始まったのかを
+    // 読みから区別できない（`ごおgぇ` = google / `せえdれあmつかう` = 英単語＋助詞なしの続き）。
+    if !is_boundary_particle(kana[split]) {
+        return None;
+    }
+    // F9/F10 の force_preedit 後などログと読みが対応しないケースを弾く。
+    if replay(romaji) != hiragana {
+        return None;
+    }
+    let romaji_chars: Vec<char> = romaji.chars().collect();
+    let romaji_prefix_len = boundaries(romaji)
+        .into_iter()
+        .find(|&(_, kana_len)| kana_len == split)
+        .map(|(romaji_len, _)| romaji_len)?;
+    let head: String = romaji_chars.get(..romaji_prefix_len)?.iter().collect();
+    // 記号・数字が混ざるものは digits.rs のリテラル保護レイヤーの担当。
+    if !head.chars().all(|c| c.is_ascii_alphanumeric())
+        || !head.chars().any(|c| c.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    let tail: String = kana[split..].iter().collect();
+    Some(format!("{head}{tail}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restores_leading_latin_word_before_kana() {
+        // 「seedreamのぺーすはどう」と打った状態
+        assert_eq!(
+            normalize_leading_latin("seedreamnope-suhadou", "せえdれあmのぺーすはどう").as_deref(),
+            Some("seedreamのぺーすはどう")
+        );
+    }
+
+    #[test]
+    fn restores_leading_latin_word_mid_typing() {
+        // 変換が追いつく前（`のぺー` まで打った時点）でも同じ位置で切れる
+        assert_eq!(
+            normalize_leading_latin("seedreamnope-", "せえdれあmのぺー").as_deref(),
+            Some("seedreamのぺー")
+        );
+    }
+
+    #[test]
+    fn ignores_pure_kana_reading() {
+        assert_eq!(normalize_leading_latin("kanntanna", "かんたんな"), None);
+    }
+
+    #[test]
+    fn ignores_reading_that_is_entirely_latin() {
+        // 読み全体が英単語 → 分ける境目が無いので対象外
+        assert_eq!(normalize_leading_latin("seedream", "せえdれあm"), None);
+    }
+
+    /// `google` / `ありがとう` の読みが想定どおりかを先に固定する。
+    /// ここがずれていると下の 2 テストが「復元しない」理由を取り違える。
+    #[test]
+    fn replay_matches_expected_readings() {
+        assert_eq!(replay("google"), "ごおgぇ");
+        assert_eq!(replay("seedreamtsukau"), "せえdれあmつかう");
+        assert_eq!(replay("seedreamnope-suhadou"), "せえdれあmのぺーすはどう");
+    }
+
+    #[test]
+    fn ignores_latin_word_whose_right_edge_is_unknown() {
+        // google は末尾の `ぇ` まで英単語だが、素の ASCII は途中の `g` が最後。
+        // ここで切ると `googlれ` に化けるので切らない。
+        assert_eq!(normalize_leading_latin("google", "ごおgぇ"), None);
+    }
+
+    #[test]
+    fn ignores_latin_word_not_followed_by_a_particle() {
+        // 助詞以外が続くと、英単語が終わったのか続いているのか読みから決まらない
+        assert_eq!(
+            normalize_leading_latin("seedreamtsukau", "せえdれあmつかう"),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_reading_out_of_sync_with_log() {
+        // force_preedit 後を模した不一致
+        assert_eq!(normalize_leading_latin("seedreamno", "SEEDREAMの"), None);
+    }
+}

--- a/crates/rakukan-engine/src/lib.rs
+++ b/crates/rakukan-engine/src/lib.rs
@@ -19,6 +19,7 @@
 // ── 統合した karukan-engine モジュール ────────────────────────────────────────
 pub mod kana;
 pub mod kanji;
+pub mod latin_run;
 pub mod romaji;
 
 pub use kana::{
@@ -588,6 +589,27 @@ impl RakunEngine {
         }
     }
 
+    /// 変換器へ渡す読み。
+    ///
+    /// ひらがなモードのまま打った先頭の英単語は、読みの上ではローマ字が
+    /// 潰れた姿（`せえdれあm`）になっている。これをそのままリテラル保護
+    /// レイヤーに渡すと素の `d` / `m` だけがアルファベット run になり、
+    /// 日本語がぶつ切りで LLM に渡って壊れる。打鍵ログから英単語を復元して
+    /// `seedreamのぺーすはどう` の形にしてから変換へ回す。
+    ///
+    /// 復元できない読み（普通の日本語 / 読み全体が英単語 / F9-F10 で
+    /// force_preedit した後）はそのまま返す。
+    pub fn conv_reading(&self) -> String {
+        crate::latin_run::normalize_leading_latin(&self.romaji_log_str(), &self.hiragana_buf)
+            .inspect(|normalized| {
+                info!(
+                    "engine::conv_reading: latin run restored {:?} -> {:?}",
+                    self.hiragana_buf, normalized
+                );
+            })
+            .unwrap_or_else(|| self.hiragana_buf.clone())
+    }
+
     pub fn convert(&self, num_candidates: usize) -> Result<Vec<String>, EngineError> {
         if self.hiragana_buf.is_empty() {
             return Ok(vec![]);
@@ -598,7 +620,7 @@ impl RakunEngine {
             .ok_or(EngineError::ModelNotInitialized)?;
         digits::convert_with_digit_protection(
             kanji,
-            &self.hiragana_buf,
+            &self.conv_reading(),
             &self.committed,
             num_candidates,
             &self.config.digit_candidates_order,
@@ -862,6 +884,7 @@ impl RakunEngine {
         }
 
         let hiragana = self.hiragana_buf.clone();
+        let conv_reading = self.conv_reading();
         let committed = self.committed.clone();
         if hiragana.is_empty() {
             return false;
@@ -873,6 +896,7 @@ impl RakunEngine {
         if let Some(conv) = self.kanji.take() {
             match conv_cache::start(
                 hiragana,
+                conv_reading,
                 committed,
                 conv,
                 n_cands,


### PR DESCRIPTION
Issue #18 の F です。棚卸しでは 2 件（「ひらがなモードの英単語破壊」「英単語の右端」）に分けていましたが、**後者は前者で入れた関数の境界判定を直すものなので、1 テーマとして 1 PR にまとめました。** 前者だけを取り込むと、境界が誤ったまま出ることになります。現行 main（`9ac120f`）基準で、他の PR とは独立です。

> ⚠ **マージ前に判断をお願いしたい点があります（末尾の「Step 10 との関係」）。**

## 症状

**`seedreamのペースはどう` と打つと `seedreamnoぺーすはどう` が確定します。**

## 原因

ひらがなモードで英単語を打つと、読みはローマ字が潰れた姿になります（`せえdれあmのぺーすはどう`）。**トライで解決できなかった子音だけが素の ASCII として残る**ため、`digits.rs` のリテラル保護レイヤーはこの `d` / `m` **だけ**をアルファベット run と判定し、`せえ` / `れあ` / `のぺーすはどう` をばらばらに LLM へ渡していました。結果は `せえdレアmのぺーす` のような読めない文字列になります。

## 変更

`romaji_input_log` は「消費されたローマ字のかたまり」を `hiragana_buf` と歩調を合わせて push しているので、**`RomajiConverter` へ流し直せばローマ字 ↔ かなの対応表を正確に作れます。** これを使って読みの先頭の英単語を打鍵どおりに復元してから変換器へ渡します（`せえdれあmのぺーすはどう` → `seedreamのぺーすはどう`）。以降は既存のリテラル保護レイヤーが `Alpha("seedream")` ＋ `Kana("のぺーすはどう")` に割るので、**LLM は日本語部分だけを見ます。**

### 英単語の右端の決め方

**素の ASCII は「ローマ字がかなに潰れきらなかった位置」を示すだけで、英単語の右端は指しません。** 最初は「最後の素の ASCII の直後」で切っていましたが、それだと `google`（読み `ごおgぇ`）は末尾の `ぇ` まで英単語なのに素の ASCII は途中の `g` が最後なので **`googlぇ` に化けます。**

そこで **素の ASCII の直後が助詞（の / を / は / が / に / で / と / も / や / へ）のときだけ「ここで英単語が終わった」と判断し、それ以外は復元しません。**

| 入力 | 読み | 結果 |
|---|---|---|
| `seedreamのぺーすはどう` | `せえdれあmのぺーすはどう` | 復元する |
| `google` | `ごおgぇ` | 復元しない（素通し） |
| `seedreamtsukau` | `せえdれあmつかう` | 復元しない |
| `claude` | `cぁうで` | 復元しない（素の ASCII が先頭の `c` だけで右端が決まらない） |

- `latin_run::normalize_leading_latin` を追加。**境界は未確定バッファを引いた位置 `(i + 1 - buffer_len)` で取ります。** 素直に数えると `seedream` の `m` が次の `n` を打つまで確定せず、復元結果が `seedreamn` になります
- `RakunEngine::conv_reading()` を追加し、`convert()` と `bg_start()` が読みの代わりにこれを渡します
- `conv_cache::Request` に**キャッシュキー（`hiragana`）と変換入力（`conv_reading`）を分けて**持たせます。結果を引くときのキーは打鍵そのままの読みです
- `replay_matches_expected_readings` を追加。**テストが「復元しない」理由を取り違えないよう、想定する読み自体を先に固定しています**

読みの途中に現れる英単語（`これはseedreamです`）は、かなが全てローマ字由来で左境界の手掛かりが打鍵ログに無いため対象外です。

## Step 10 との関係（判断をお願いします）

Issue #18 では「実装箇所が未確定ローマ字の再構築に触れていなければ」という条件をいただきました。**触れてはいませんが、`romaji_input_log` を読んで再生します。**

- `normalize_leading_latin()` は**純粋関数**で、入力は `(打鍵ログを連結した文字列, 読み)` の 2 つだけです。`pending_romaji_buf` / `hiragana_buf` / `romaji_input_log` を**書き換えません。** Backspace の経路にも触れません
- ただし **Step 10 で `romaji_input_log` の要素表現を変える場合、この再生も合わせて直す必要があります。** 「入力文字列からローマ字状態を再生する処理を分離する」という Step 10 の作業に対して、再生ロジックが一時的に 2 箇所になる形です

**Step 10 の再生処理へ後で寄せる前提で今マージするか、Step 10 の後に出し直すか、決めていただければそれに従います。**

## 確認

- `cargo test -p rakukan-engine --release --lib` — 186 passed / 0 failed / 2 ignored
- `cargo clippy -p rakukan-engine --release --all-targets -- -D warnings` — 警告なし
- `cargo fmt --all -- --check` — 差分なし

`conv_cache::start()` は引数が 1 つ増えて 8 個になり `clippy::too_many_arguments` に当たるため、理由コメント付きで `#[allow]` を置いています。**構造体へまとめる形が良ければ直します**（`Request` と二重になるので今回は避けました）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
