### PR TITLE
fix(settings): 設定画面でマウスホイールのスクロールが効かない問題を修正

### DIFF
--- a/apps/rakukan-settings-winui/MainWindow.xaml.cs
+++ b/apps/rakukan-settings-winui/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Windows.Graphics;
 
@@ -25,7 +26,7 @@ public sealed partial class MainWindow : Window
     {
         InitializeComponent();
         SetWindowIcon();
-        AppWindow.Resize(new SizeInt32(1080, 760));
+        ResizeToDefaultSize();
         AppWindow.Closing += AppWindow_Closing;
 
         var ver = Assembly.GetEntryAssembly()?.GetName().Version;
@@ -786,4 +787,20 @@ public sealed partial class MainWindow : Window
         }
     }
 
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(IntPtr hwnd);
+
+    // AppWindow.Resize は物理ピクセル指定なので、表示先のスケーリングに合わせて
+    // 拡大しないと高 DPI 環境でウィンドウが小さくなり中身が収まらない。
+    private void ResizeToDefaultSize()
+    {
+        const int baseWidth = 1080;
+        const int baseHeight = 760;
+
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        var dpi = GetDpiForWindow(hwnd);
+        var scale = dpi == 0 ? 1.0 : dpi / 96.0;
+
+        AppWindow.Resize(new SizeInt32((int)(baseWidth * scale), (int)(baseHeight * scale)));
+    }
 }

--- a/apps/rakukan-settings-winui/app.manifest
+++ b/apps/rakukan-settings-winui/app.manifest
@@ -8,4 +8,13 @@
       </requestedPrivileges>
     </security>
   </trustInfo>
+  <!-- WinUI 3 は Per-Monitor V2 DPI awareness を前提としている。宣言が無いと
+       プロセスが DPI unaware になり、DPI 仮想化でポインタの座標系がずれて
+       マウスホイールによるスクロールが効かなくなる。 -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
 </assembly>


### PR DESCRIPTION
## 症状

設定画面の各ページを、マウスホイールでスクロールできません。スクロールバーを
ドラッグすればスクロールできるため、`ScrollViewer` 自体は機能しています。

## 原因

`app.manifest` に DPI awareness の宣言が無く、設定アプリのプロセスが
`PROCESS_DPI_UNAWARE` で起動していました (`GetProcessDpiAwareness` で確認)。

WinUI 3 は Per-Monitor V2 を前提としており、DPI 仮想化された状態ではポインタの
座標系がずれます。クリックやスクロールバーのドラッグは OS が座標を変換するので
効きますが、マウスホイールのヒットテストだけが通らず、ディスプレイのスケーリングが
100% 以外の環境ではホイールスクロールがまったく効かない状態になります。

## 修正

- `app.manifest` に `dpiAware` / `dpiAwareness` (PerMonitorV2) を宣言
- `AppWindow.Resize` は物理ピクセル指定のため、`GetDpiForWindow` で取得した
  スケールを掛けて従来と同じ表示サイズを保つ。宣言前は DPI 仮想化によって実質
  スケールされていたので、この調整が無いと高 DPI 環境でウィンドウが小さくなります

## 確認

スケーリングが 100% 以外のディスプレイで、修正前は全ページでホイールが効かず、
修正後は効くようになることを確認しました。プロセスの awareness が
`PROCESS_PER_MONITOR_DPI_AWARE` に変わることも確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
