### PR TITLE
fix(install): ロックされた DLL を退避リネームして差し替える

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -193,6 +193,34 @@ if ($engineDlls.Count -eq 0) {
 # [1/5] Copy to LocalAppData
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ロック済みの DLL を、退避リネームを挟んで差し替える。
+#
+# 上書きコピーが IOException になるのは、旧 DLL を掴んだプロセスが残っている時。
+# リネームはマップ済みでも通るので、`<name>.locked-<timestamp>` へ逃がしてから
+# コピーする。退避したファイルは掴んでいるプロセスが終わるまで消せないので、
+# 次回以降の実行でまとめて best-effort に削除する。
+function Copy-DllOverLocked {
+    param([string]$Source, [string]$Destination)
+
+    # 前回以前の退避ファイルを掃除（まだ掴まれていれば失敗するので黙って飛ばす）
+    $dir  = Split-Path -Parent $Destination
+    $name = Split-Path -Leaf $Destination
+    Get-ChildItem -LiteralPath $dir -Filter "$name.locked-*" -ErrorAction SilentlyContinue |
+        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+
+    try {
+        Copy-Item -LiteralPath $Source -Destination $Destination -Force
+        return
+    } catch [System.IO.IOException] {
+        if (-not (Test-Path -LiteralPath $Destination)) { throw }
+    }
+
+    $parked = "$Destination.locked-" + (Get-Date -Format "yyyyMMdd_HHmmss")
+    Move-Item -LiteralPath $Destination -Destination $parked -Force
+    Write-Host "  (locked) $name -> $(Split-Path -Leaf $parked)" -ForegroundColor DarkGray
+    Copy-Item -LiteralPath $Source -Destination $Destination -Force
+}
+
 Write-Host "[1/5] Installing to $installDir ..."
 New-Item -ItemType Directory -Force -Path $installDir | Out-Null
 
@@ -211,8 +239,14 @@ Stop-ProcSilent "TextInputHost"
 Start-Sleep -Milliseconds 1200
 
 # TSF DLL
+# 旧 DLL は「差し替え前から動いているアプリ」にマップされたままなので、
+# ctfmon を止めても上書きコピーは IOException になる。Windows はマップ済みの
+# ファイルでもリネームは通す（ローダーが FILE_SHARE_DELETE で開いているため）
+# ので、ロックされていたら退避名へ改名してから置く。これでサインアウトせずに
+# 差し替えられる。旧 DLL を掴んでいるアプリは再起動するまで旧 DLL のまま動く
+# （新しく起動したプロセスは新 DLL を読む）。
 $dst = Join-Path $installDir "rakukan_tsf.dll"
-Copy-Item -LiteralPath $srcDll -Destination $dst -Force
+Copy-DllOverLocked -Source $srcDll -Destination $dst
 Write-Host "  -> $dst"
 
 # 古いタイムスタンプ付き DLL を削除
@@ -231,7 +265,9 @@ Get-ChildItem -Path $installDir -Filter "rakukan_tsf_????????_??????.dll" -Error
 foreach ($engineDll in $engineDlls) {
     $dllName = [IO.Path]::GetFileName($engineDll)
     $engineDst = Join-Path $installDir $dllName
-    Copy-Item -LiteralPath $engineDll -Destination $engineDst -Force
+    # engine host は kill しても次の入力で即 respawn して DLL を掴み直すため、
+    # TSF DLL と同じ退避を通す。
+    Copy-DllOverLocked -Source $engineDll -Destination $engineDst
     Write-Host "  -> $engineDst"
 }
 


### PR DESCRIPTION
## 症状

`scripts\install.ps1` が `rakukan_tsf.dll` のコピーで必ず失敗し、「一旦サインアウト→再ログオンしてから再実行してください」と案内して終了します。ビルドのたびにサインアウトが 1 往復挟まる状態でした。

```
[install] ファイルがロックされていてコピーできません:
  別のプロセスで使用されているため、プロセスはファイル
  'C:\Users\<user>\AppData\Local\rakukan\rakukan_tsf.dll' にアクセスできません。
```

## 原因

TSF DLL は差し替え前から動いているアプリのプロセスにマップされたままで、コピーの直前で `ctfmon` / `TextInputHost` を止めても解放されません。

## 修正

Windows はマップ済みのファイルでも**リネームは通します**（ローダーが `FILE_SHARE_DELETE` で開いているため）。上書きに失敗した場合だけ `<name>.locked-<timestamp>` へ逃がしてからコピーする `Copy-DllOverLocked` を追加し、TSF DLL と engine DLL の両方をこれに通しました（engine host は kill しても次の入力で respawn して掴み直すため、同じ問題が起きます）。

- 退避したファイルは掴んでいるプロセスが終わるまで消せないので、次回以降の実行で best-effort に削除します
- 退避後のコピーにも失敗した場合、および差し替え先がまだ存在しない（＝ロックではない）場合は、従来どおり例外を投げて既存のロック案内へ落ちます

旧 DLL を掴んだままのアプリが再起動するまで旧 DLL で動き続ける点は従来と同じで、この変更で新たに生じるものではありません。

## 確認

こちらの環境（Windows 11 26200）で、**サインアウトせずに** TSF DLL / engine DLL / engine-host.exe / tray.exe の差し替えが完了し、`rakukan_tsf.dll.locked-20260906_130244` が退避されることを確認しました。差し替え後に起動し直したアプリで新しい DLL が読まれることも確認しています。

※ 実行して確かめたのはこちらの統合ブランチ上の同一パッチで、この PR は現行 main（`56ac510`）へ同じ変更を当て直したものです。main の該当箇所は素の `Copy-Item -Force` で、こちらと同じコードでした。`Parser::ParseFile` による構文チェックと、BOM 付き UTF-8 / CRLF が保たれていることは PR head で確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
