### PR TITLE
feat(engine): 記号の連打を三点リーダーへ畳む設定を追加（既定 off）

### DIFF
--- a/crates/rakukan-engine/src/lib.rs
+++ b/crates/rakukan-engine/src/lib.rs
@@ -251,6 +251,9 @@ pub struct EngineConfig {
     /// 詳細は `kanji::ConversionConfig::min_top_confidence` を参照。
     #[serde(default)]
     pub min_top_confidence: Option<f32>,
+    /// 記号の連打を三点リーダー `⋯` へ畳む（`。。。` / `・・・` / `、、、`）。既定 off。
+    #[serde(default)]
+    pub symbol_repeat_ellipsis: bool,
 }
 
 fn default_confidence_margin() -> Option<f32> {
@@ -274,6 +277,7 @@ impl Default for EngineConfig {
             convert_beam_size: 30,
             confidence_margin: default_confidence_margin(),
             min_top_confidence: None,
+            symbol_repeat_ellipsis: false,
         }
     }
 }
@@ -355,6 +359,22 @@ fn alpha_symbol_separator_auto(
     }
 }
 
+/// 記号の連打を 1 文字へ畳む規則（読みの末尾一致 → 置換）。上から順に試す。
+///
+/// `。。。` は三点リーダーの代用として最も多く打たれる形で、`・・・` / `、、、` も
+/// 同じ意図。`...` / `．．．` は英字直後（`alpha_symbol_separator_auto` が `.` を
+/// 和文の `。` にしない経路）で出る形。出力は中央寄せの `⋯`（U+22EF）。
+/// `…`（U+2026）は欧文フォントでベースラインに沈むので使わない。
+/// 二点リーダー `‥` は `z,` で打てるのでここでは扱わない（`、、` を畳むと
+/// 読点 2 連の打ち間違いを巻き込む）。
+const SYMBOL_REPEAT_RULES: &[(&str, &str)] = &[
+    ("。。。", "⋯"),
+    ("・・・", "⋯"),
+    ("、、、", "⋯"),
+    ("．．．", "⋯"),
+    ("...", "⋯"),
+];
+
 pub struct RakunEngine {
     romaji: RomajiConverter,
     kanji: Option<KanaKanjiConverter>,
@@ -433,6 +453,52 @@ impl RakunEngine {
     }
 
     pub fn push_char(&mut self, c: char) -> PreeditState {
+        let before = self.hiragana_buf.len();
+        self.push_char_inner(c);
+        // 読みが伸びた打鍵だけを見る。force_preedit で置かれた末尾を、無関係な
+        // 次の打鍵で遡って畳まないため。
+        if self.hiragana_buf.len() > before {
+            self.collapse_symbol_repeat();
+        }
+        self.current_preedit()
+    }
+
+    /// 記号の連打を 1 文字へ畳む（`。。。` → `⋯`）。`symbol_repeat_ellipsis` が
+    /// off（既定）なら何もしない。
+    ///
+    /// `。。。` のような読みは変換に載らない。TSF 側の `split_by_punctuation` が
+    /// 句読点で読みを切るので、記号だけのブロックは候補ゼロで捨てられる
+    /// （ユーザー辞書に `。。。` を登録しても引かれない）。ローマ字テーブルに
+    /// `...` を足す案も、`.` に子ノードができて `。` の表示が 1 打鍵遅れるので不可。
+    /// 入力段で hiragana_buf の末尾を見て置き換えるのが唯一の経路。
+    ///
+    /// romaji converter の output と打鍵ログも同じ幅で縮める。これで Backspace が
+    /// `⋯` を 1 回で消し、F6〜F10 の復元（打鍵ログの再生）も `⋯` を再現する。
+    fn collapse_symbol_repeat(&mut self) -> bool {
+        if !self.config.symbol_repeat_ellipsis {
+            return false;
+        }
+        let Some((pattern, output)) = SYMBOL_REPEAT_RULES
+            .iter()
+            .find(|(pattern, _)| self.hiragana_buf.ends_with(pattern))
+        else {
+            return false;
+        };
+        let n = pattern.chars().count();
+        let keep = self.hiragana_buf.len() - pattern.len();
+        self.hiragana_buf.truncate(keep);
+        self.hiragana_buf.push_str(output);
+        self.romaji.replace_output_tail(pattern, output);
+        // 記号は 1 文字 = 1 エントリで積まれている（trie / push_raw / separator の
+        // どの経路でも）ので、末尾 n 件をまとめて置き換える。
+        let keep = self.romaji_input_log.len().saturating_sub(n);
+        self.romaji_input_log.truncate(keep);
+        self.romaji_input_log.push(output.to_string());
+        debug!("engine::push: symbol repeat {:?} → {:?}", pattern, output);
+        true
+    }
+
+    fn push_char_inner(&mut self, c: char) -> PreeditState {
         if self.config.digit_separator_auto
             && self.pending_romaji_buf.is_empty()
             && let Some(separator) =
@@ -543,6 +609,9 @@ impl RakunEngine {
     pub fn push_raw(&mut self, c: char) {
         self.hiragana_buf.push(c);
         self.romaji_input_log.push(c.to_string());
+        // TSF は `.` `,` `/` を `direct_input_symbol` で和文記号に変えてから
+        // この経路で積む（`push_char` を通らない）ので、ここでも畳む。
+        self.collapse_symbol_repeat();
     }
 
     /// Shift+アルファベット用: alpha_width 設定に従って全角 or 半角の大文字を hiragana_buf に追加。
@@ -1143,6 +1212,123 @@ mod symbol_input_tests {
         e.force_preedit("2".to_string());
         e.push_char(',');
         assert_eq!(e.hiragana_text(), "2、");
+    }
+
+    // ─── 記号の連打を三点リーダーへ畳む（input.symbol_repeat_ellipsis） ────────
+
+    fn ellipsis_config() -> crate::EngineConfig {
+        crate::EngineConfig {
+            symbol_repeat_ellipsis: true,
+            ..Default::default()
+        }
+    }
+
+    fn push_ellipsis(buf_init: &str, c: char) -> String {
+        let mut e = RakunEngine::new(ellipsis_config());
+        e.force_preedit(buf_init.to_string());
+        e.push_char(c);
+        e.hiragana_text().to_string()
+    }
+
+    #[test]
+    fn symbol_repeat_is_not_collapsed_by_default() {
+        // 既定 off。設定を入れていない利用者の入力は一切変わらない。
+        let mut e = RakunEngine::new(crate::EngineConfig::default());
+        for _ in 0..3 {
+            e.push_char('.');
+        }
+        assert_eq!(e.hiragana_text(), "。。。");
+        e.push_raw('。');
+        assert_eq!(e.hiragana_text(), "。。。。");
+    }
+
+    #[test]
+    fn three_maru_collapse_to_midline_ellipsis() {
+        let mut e = RakunEngine::new(ellipsis_config());
+        e.push_char('.');
+        e.push_char('.');
+        assert_eq!(e.hiragana_text(), "。。");
+        e.push_char('.');
+        assert_eq!(e.hiragana_text(), "⋯");
+        // 6 連で 2 つ
+        for _ in 0..3 {
+            e.push_char('.');
+        }
+        assert_eq!(e.hiragana_text(), "⋯⋯");
+    }
+
+    #[test]
+    fn push_raw_repeat_collapses_and_backspaces_as_one() {
+        // TSF の on_punctuate 経路（ローマ字変換を通らない）
+        let mut e = RakunEngine::new(ellipsis_config());
+        for c in "sou".chars() {
+            e.push_char(c);
+        }
+        for _ in 0..3 {
+            e.push_raw('。');
+        }
+        assert_eq!(e.hiragana_text(), "そう⋯");
+        assert!(e.backspace());
+        assert_eq!(e.hiragana_text(), "そう");
+        assert_eq!(e.hiragana_from_romaji_log(), "そう");
+    }
+
+    #[test]
+    fn nakaten_touten_and_western_period_repeat_collapse() {
+        assert_eq!(push_ellipsis("・・", '/'), "⋯");
+        assert_eq!(push_ellipsis("、、", ','), "⋯");
+        // 英字直後の `.` は `．` になる経路（alpha_width=fullwidth 既定）
+        assert_eq!(push_ellipsis("ａ．．", '.'), "ａ⋯");
+        // 半角設定なら `...` のまま積まれてから畳まれる
+        let config = crate::EngineConfig {
+            alpha_width: crate::AlphaWidth::Halfwidth,
+            symbol_width: crate::SymbolWidth::Halfwidth,
+            ..ellipsis_config()
+        };
+        let mut e = RakunEngine::new(config);
+        e.push_fullwidth_alpha('A');
+        for _ in 0..3 {
+            e.push_char('.');
+        }
+        assert_eq!(e.hiragana_text(), "A⋯");
+    }
+
+    #[test]
+    fn ellipsis_then_period_is_japanese_maru() {
+        // `⋯` は英字・記号扱いにならないので直後の `.` は `。`
+        assert_eq!(push_ellipsis("⋯", '.'), "⋯。");
+    }
+
+    #[test]
+    fn ellipsis_backspace_removes_whole_symbol() {
+        let mut e = RakunEngine::new(ellipsis_config());
+        for c in "sou...".chars() {
+            e.push_char(c);
+        }
+        assert_eq!(e.hiragana_text(), "そう⋯");
+        assert!(e.backspace());
+        assert_eq!(e.hiragana_text(), "そう");
+        assert!(e.backspace());
+        assert_eq!(e.hiragana_text(), "そ");
+    }
+
+    #[test]
+    fn ellipsis_survives_romaji_log_restore() {
+        let mut e = RakunEngine::new(ellipsis_config());
+        for c in "a...".chars() {
+            e.push_char(c);
+        }
+        assert_eq!(e.hiragana_text(), "あ⋯");
+        assert_eq!(e.hiragana_from_romaji_log(), "あ⋯");
+    }
+
+    #[test]
+    fn force_preedit_tail_is_not_collapsed_by_unrelated_key() {
+        // force_preedit で置かれた `。。。` は、読みを伸ばさない打鍵では畳まない
+        let mut e = RakunEngine::new(ellipsis_config());
+        e.force_preedit("。。。".to_string());
+        e.push_char('k'); // pending に留まる
+        assert_eq!(e.hiragana_text(), "。。。");
     }
 
     #[test]

--- a/crates/rakukan-engine/src/romaji/converter.rs
+++ b/crates/rakukan-engine/src/romaji/converter.rs
@@ -228,6 +228,28 @@ impl RomajiConverter {
         }
     }
 
+    /// 出力末尾を `pattern` と一致する範囲だけ削り、`insert` に置き換える。
+    ///
+    /// 記号の連打を 1 文字へ畳む（`。。。` → `⋯`）とき、engine 側の
+    /// `hiragana_buf` と歩調を合わせるために使う。`push_raw` 経由で来た
+    /// 記号は output に載っていないので、末尾から一致する分だけ削る。
+    /// 1 文字も一致しなければ何もしない（その場合 backspace は `Empty` 経由で
+    /// hiragana_buf だけを削るので整合する）。
+    pub fn replace_output_tail(&mut self, pattern: &str, insert: &str) {
+        let mut removed = 0;
+        for expected in pattern.chars().rev() {
+            if self.output.ends_with(expected) {
+                self.output.pop();
+                removed += 1;
+            } else {
+                break;
+            }
+        }
+        if removed > 0 {
+            self.output.push_str(insert);
+        }
+    }
+
     /// Get the current output
     pub fn output(&self) -> &str {
         &self.output

--- a/crates/rakukan-tsf/src/engine/config.rs
+++ b/crates/rakukan-tsf/src/engine/config.rs
@@ -218,6 +218,10 @@ pub struct InputConfig {
     /// 数字候補の表示順。指定した種別だけを候補に出す。
     #[serde(default = "default_digit_candidates_order")]
     pub digit_candidates_order: Vec<DigitCandidateKind>,
+    /// 記号の連打を三点リーダー `⋯` へ畳む（`。。。` / `・・・` / `、、、`）。
+    /// 既定 `false`（従来どおり打った記号がそのまま残る）。
+    #[serde(default)]
+    pub symbol_repeat_ellipsis: bool,
     /// 確定時に学習するか (デフォルト `true`)。
     /// Phase 1: 従来どおり user_dict.toml に追記される (肥大化注意)。
     /// Phase 2 以降: 独立した learn_history に記録され user_dict.toml には書かない。
@@ -239,6 +243,7 @@ impl Default for InputConfig {
             symbol_width: SymbolWidth::default(),
             digit_separator_auto: default_digit_separator_auto(),
             digit_candidates_order: default_digit_candidates_order(),
+            symbol_repeat_ellipsis: false,
             auto_learn: default_auto_learn(),
         }
     }
@@ -579,6 +584,8 @@ symbol_width = "fullwidth"
 digit_separator_auto = true
 # 数字だけの reading に対して提示する候補種別と順序
 digit_candidates_order = ["arabic", "fullwidth", "positional", "per_digit", "daiji"]
+# 記号の連打を三点リーダー ⋯ へ畳む (。。。 / ・・・ / 、、、 / ．．． / ...)
+symbol_repeat_ellipsis = false
 # 確定時に学習するか (デフォルト: true)。
 # false にすると学習を完全に抑止する。
 auto_learn = true

--- a/crates/rakukan-tsf/src/engine/state.rs
+++ b/crates/rakukan-tsf/src/engine/state.rs
@@ -658,6 +658,7 @@ fn build_engine_config_json() -> String {
     let live_conv_beam_size = cfg.live_conversion.beam_size.clamp(1, 9);
     let convert_beam_size = cfg.conversion.beam_size.clamp(1, 30);
     let digit_separator_auto = cfg.input.digit_separator_auto;
+    let symbol_repeat_ellipsis = cfg.input.symbol_repeat_ellipsis;
     let digit_candidates_order = cfg
         .input
         .digit_candidates_order
@@ -673,14 +674,14 @@ fn build_engine_config_json() -> String {
         .join(",");
 
     tracing::info!(
-        "engine config: num_candidates={num_candidates} n_gpu_layers={n_gpu_layers} main_gpu={main_gpu} model_variant={model_variant:?} digit_width={digit_width} alpha_width={alpha_width} symbol_width={symbol_width} digit_separator_auto={digit_separator_auto} digit_candidates_order=[{digit_candidates_order}] live_conv_beam_size={live_conv_beam_size} convert_beam_size={convert_beam_size}"
+        "engine config: num_candidates={num_candidates} n_gpu_layers={n_gpu_layers} main_gpu={main_gpu} model_variant={model_variant:?} digit_width={digit_width} alpha_width={alpha_width} symbol_width={symbol_width} digit_separator_auto={digit_separator_auto} symbol_repeat_ellipsis={symbol_repeat_ellipsis} digit_candidates_order=[{digit_candidates_order}] live_conv_beam_size={live_conv_beam_size} convert_beam_size={convert_beam_size}"
     );
     let mv_json = match &model_variant {
         Some(v) => format!(r#","model_variant":"{}""#, v),
         None => String::new(),
     };
     format!(
-        r#"{{"num_candidates":{num_candidates},"n_gpu_layers":{n_gpu_layers},"main_gpu":{main_gpu},"n_threads":0,"digit_width":"{digit_width}","alpha_width":"{alpha_width}","symbol_width":"{symbol_width}","digit_separator_auto":{digit_separator_auto},"digit_candidates_order":[{digit_candidates_order}],"live_conv_beam_size":{live_conv_beam_size},"convert_beam_size":{convert_beam_size}{mv_json}}}"#
+        r#"{{"num_candidates":{num_candidates},"n_gpu_layers":{n_gpu_layers},"main_gpu":{main_gpu},"n_threads":0,"digit_width":"{digit_width}","alpha_width":"{alpha_width}","symbol_width":"{symbol_width}","digit_separator_auto":{digit_separator_auto},"symbol_repeat_ellipsis":{symbol_repeat_ellipsis},"digit_candidates_order":[{digit_candidates_order}],"live_conv_beam_size":{live_conv_beam_size},"convert_beam_size":{convert_beam_size}{mv_json}}}"#
     )
 }
 

--- a/crates/rakukan-tsf/src/engine/text_util.rs
+++ b/crates/rakukan-tsf/src/engine/text_util.rs
@@ -775,8 +775,9 @@ pub fn to_half_katakana(s: &str) -> String {
 /// これらは LLM に渡さない delimiter として扱う。
 #[inline]
 pub fn is_kuten(c: char) -> bool {
-    // 日本語区読点（FF01-FF5E 外）
-    if matches!(c, '、' | '。') {
+    // 日本語区読点（FF01-FF5E 外）。リーダー類は engine が `。。。` 等を
+    // 畳んで作る記号で、句点と同じく変換対象から外す。
+    if matches!(c, '、' | '。' | '⋯' | '…' | '‥') {
         return true;
     }
     let n = c as u32;
@@ -862,6 +863,27 @@ pub(crate) fn split_symbol_affixes(s: &str) -> Option<(String, String, String)> 
     }
 
     Some((prefix.to_string(), target.to_string(), suffix.to_string()))
+}
+
+/// engine の読みが `before` → `after` へ変わったときの末尾差分。
+///
+/// 戻り値 `(removed, added)`: `before` の末尾から `removed` 文字を消して
+/// `added` を足すと `after` になる。`on_punctuate` は記号を engine に積んだ
+/// あと session 側の表示文字列を自前で組み立てるので、engine が末尾を
+/// 畳んだ（`。。。` → `⋯`）ときに同じ操作を表示側にも当てるために使う。
+pub(crate) fn tail_delta(before: &str, after: &str) -> (usize, String) {
+    let b: Vec<char> = before.chars().collect();
+    let a: Vec<char> = after.chars().collect();
+    let common = b.iter().zip(a.iter()).take_while(|(x, y)| x == y).count();
+    (b.len() - common, a[common..].iter().collect())
+}
+
+/// [`tail_delta`] の結果を別の文字列の末尾に当てる。
+pub(crate) fn apply_tail_delta(s: &mut String, removed: usize, added: &str) {
+    for _ in 0..removed {
+        s.pop();
+    }
+    s.push_str(added);
 }
 
 /// 文字列が区読点を含むかどうか。
@@ -1046,6 +1068,30 @@ mod tests {
     fn romaji_log_latin_convert_japanese_symbols() {
         assert_eq!(romaji_to_fullwidth_latin("、。・-"), "，．／－");
         assert_eq!(romaji_to_halfwidth_latin("、。・-"), ",./-");
+    }
+
+    // ─── tail_delta ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn tail_delta_plain_append() {
+        assert_eq!(tail_delta("そう。。", "そう。。。"), (0, "。".to_string()));
+    }
+
+    #[test]
+    fn tail_delta_collapse() {
+        assert_eq!(tail_delta("そう。。", "そう⋯"), (2, "⋯".to_string()));
+        let mut preview = "騒。。".to_string();
+        apply_tail_delta(&mut preview, 2, "⋯");
+        assert_eq!(preview, "騒⋯");
+    }
+
+    #[test]
+    fn ellipsis_is_kuten() {
+        assert!(is_kuten('⋯'));
+        assert_eq!(
+            split_symbol_affixes("そうか⋯"),
+            Some(("".to_string(), "そうか".to_string(), "⋯".to_string()))
+        );
     }
 
     // ─── split_by_punctuation ─────────────────────────────────────────────────

--- a/crates/rakukan-tsf/src/tsf/factory/edit_ops.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/edit_ops.rs
@@ -533,13 +533,17 @@ impl super::TextServiceFactory_Impl {
         }
 
         if sess.is_live_conv() {
-            let (reading, preview) = sess
+            let (mut next_reading, mut display) = sess
                 .live_conv_parts()
                 .map(|(r, p)| (r.to_string(), p.to_string()))
                 .unwrap_or_default();
+            // engine が末尾を畳む（`。。。` → `⋯`）ことがあるので、記号をそのまま
+            // 足さず engine の読みの差分を表示側にも当てる。畳みが off なら
+            // 差分は「記号 1 文字を足す」と同じになる。
             engine.push_raw(symbol);
-            let display = format!("{preview}{symbol}");
-            let next_reading = format!("{reading}{symbol}");
+            let (removed, added) = text_util::tail_delta(&reading_before, &engine.hiragana_text());
+            text_util::apply_tail_delta(&mut next_reading, removed, &added);
+            text_util::apply_tail_delta(&mut display, removed, &added);
             sess.set_live_conv(next_reading.clone(), display.clone(), next_reading);
             drop(sess);
             drop(guard);
@@ -548,12 +552,13 @@ impl super::TextServiceFactory_Impl {
         }
 
         if sess.is_block_selecting() {
-            let full_text = sess.block_selecting_full_text().unwrap_or_default();
-            let full_reading = sess.block_selecting_full_reading().unwrap_or_default();
-            engine.force_preedit(full_reading.clone());
+            let mut display = sess.block_selecting_full_text().unwrap_or_default();
+            let mut next_reading = sess.block_selecting_full_reading().unwrap_or_default();
+            engine.force_preedit(next_reading.clone());
             engine.push_raw(symbol);
-            let display = format!("{full_text}{symbol}");
-            let next_reading = format!("{full_reading}{symbol}");
+            let (removed, added) = text_util::tail_delta(&next_reading, &engine.hiragana_text());
+            text_util::apply_tail_delta(&mut next_reading, removed, &added);
+            text_util::apply_tail_delta(&mut display, removed, &added);
             sess.set_live_conv(next_reading.clone(), display.clone(), next_reading);
             drop(sess);
             drop(guard);
@@ -576,8 +581,17 @@ impl super::TextServiceFactory_Impl {
             if remainder_reading.is_empty() {
                 remainder_reading = remainder.clone();
             }
-            let display = format!("{prefix}{text}{symbol}{remainder}");
-            let next_reading = format!("{prefix_reading}{reading}{symbol}{remainder_reading}");
+            // 記号は engine に積んで畳み込み（`。。。` → `⋯`）を通し、その差分を
+            // 表示側にも当てる。remainder は畳み込みの対象外なので後から足す。
+            let mut head_display = format!("{prefix}{text}");
+            let mut head_reading = format!("{prefix_reading}{reading}");
+            engine.force_preedit(head_reading.clone());
+            engine.push_raw(symbol);
+            let (removed, added) = text_util::tail_delta(&head_reading, &engine.hiragana_text());
+            text_util::apply_tail_delta(&mut head_reading, removed, &added);
+            text_util::apply_tail_delta(&mut head_display, removed, &added);
+            let display = format!("{head_display}{remainder}");
+            let next_reading = format!("{head_reading}{remainder_reading}");
             engine.force_preedit(next_reading.clone());
             sess.set_live_conv(next_reading.clone(), display.clone(), next_reading);
             drop(sess);
@@ -587,9 +601,10 @@ impl super::TextServiceFactory_Impl {
         }
 
         if sess.is_waiting() {
-            let text = sess.preedit_text().unwrap_or("").to_string();
+            let mut display = sess.preedit_text().unwrap_or("").to_string();
             engine.push_raw(symbol);
-            let display = format!("{text}{symbol}");
+            let (removed, added) = text_util::tail_delta(&reading_before, &engine.hiragana_text());
+            text_util::apply_tail_delta(&mut display, removed, &added);
             sess.set_preedit(display.clone());
             drop(sess);
             drop(guard);


### PR DESCRIPTION
> **訂正（2026-09-10）**
>
> - **この PR は下の説明と違い「既定 off」になっていません。** TSF は `input.symbol_repeat_ellipsis` を engine 設定 JSON に載せていますが、`rakukan-engine` の `EngineConfig` に対応するフィールドが無く、`#[serde(default)]` の構造体なので未知キーとして捨てられます。`collapse_symbol_repeat()` は `push_char` / `push_raw` から無条件に呼ばれるため、設定値に関係なく常に畳みます。「off のときの挙動は現行と 1 文字も変わらない」「既定 off の確認テスト」も成り立っていません。
> - 「二点リーダー `‥` は `z,` で打てる」も誤りです。TSF が `.` `,` `/` `[` `]` を記号入力経路へ先に回すため、trie の `z.` `z,` はキーボードから到達できません（#34 の問題点 4）。
>
> 方式は #35 で検討中のため、この PR はそのままにしてあります。以下は提出時の説明です。

---

Issue #18 の **G（記号）** です。「設定で opt-in・既定 off」というご指定に合わせて、新しい設定キー `input.symbol_repeat_ellipsis`（既定 `false`）の下に入れました（**実際には効いていません。上の訂正を参照**）。

## 何をするか

読みの末尾が記号の 3 連なら 1 文字の三点リーダー `⋯`（U+22EF）へ畳みます。

| 打鍵 | 読み |
|---|---|
| `.` `.` `.` | `。。。` → `⋯` |
| `/` `/` `/` | `・・・` → `⋯` |
| `,` `,` `,` | `、、、` → `⋯` |
| 英字直後の `.` `.` `.` | `．．．` / `...` → `⋯` |

## なぜ入力段で畳むか

`。。。` は変換に載りません。`split_by_punctuation` が句読点で読みを切るので、記号だけのブロックは候補ゼロで捨てられます（ユーザー辞書に `。。。` を登録しても引かれません）。ローマ字テーブルに `...` を足す案も、`.` に子ノードができて `。` の表示が 1 打鍵遅れるので採れませんでした。残るのは入力段で `hiragana_buf` の末尾を見て置き換える経路だけです。

出力は中央寄せの `⋯`（U+22EF）にしています。`…`（U+2026）は欧文フォントでベースラインに沈むためです。二点リーダー `‥` は扱っていません（`、、` を畳むと読点 2 連の打ち間違いを巻き込むためで、上の訂正のとおり `z,` からは打てません）。

## 実装

- **engine**: `push_char` を薄いラッパにして、**読みが伸びた打鍵のときだけ** `collapse_symbol_repeat()` を通します。`force_preedit` で置かれた末尾を、無関係な次の打鍵で遡って畳まないためです。畳むときは `romaji` の output と `romaji_input_log` も同じ幅で縮めるので、Backspace が `⋯` を 1 回で消し、F6〜F10 の復元（打鍵ログの再生）も `⋯` を再現します。なお `romaji_input_log` の書き換えは #34 の不変条件「log + pending == 打鍵列」と衝突します。
- **`push_raw` にも同じ畳み込みを入れています**。TSF は `.` `,` `/` を `direct_input_symbol` で和文記号に変えてから `push_raw` で積むので（`push_char` を通りません）、こちらが本命の経路です。
- **TSF `on_punctuate`**: 記号をそのまま表示文字列へ足す代わりに、engine の読みの末尾差分（`tail_delta` / `apply_tail_delta`）を表示側にも当てます。**表示の末尾が読みの末尾記号と同じ文字であることが前提**です。また候補選択中（`is_selecting`）の分岐は `force_preedit` → `push_raw` の順で積むため、畳み込みが起きると `truncate(len - 3)` が remainder 由来の打鍵ログを消します（レビュー指摘 2、未修正）。
- **`is_kuten` にリーダー類 `⋯` `…` `‥` を追加**しました。ここは純粋関数で config を持たないため設定に依りません。

## 設定

`%APPDATA%\rakukan\config.toml` の `[input]` に 1 行です。GUI は追加していません（`SettingsStore.SaveConfig` は読み込んだ TomlTable を編集するので、設定画面で保存しても未知キーは残ります）。

```toml
[input]
symbol_repeat_ellipsis = false  # true で 。。。 → ⋯（※ 現状このキーは engine 側で読まれていません）
```

## テスト

engine 側 8 本（3 連の畳み込み、`push_raw` 経路、Backspace 1 回で消える、打鍵ログ復元、`force_preedit` の末尾を畳まない など）と、TSF 側 3 本（`tail_delta` の追記・畳み込み、`is_kuten`）を追加しました。いずれも `EngineConfig::default()` で畳む前提の内容で、**off 側を確認したテストはありません**。

手元で通したのは次の 3 つです。

- `cargo fmt --all -- --check`
- `cargo clippy -p rakukan-tsf --release --all-targets -- -D warnings`
- `cargo test -p rakukan-tsf --release`（102 passed）

**engine 側のテストは手元で実行できていません。** この作業機に libclang が見当たらず `llama-cpp-sys-2` の bindgen が通らないためで、`cargo test -p rakukan-engine --release --lib` は CI の結果を見ています。

機能自体は統合ブランチ側で毎日踏んでいるものですが、**この PR は現行 main へ移植し直したもの**で、設定ゲートは移植にあたって足した（つもりだった）ものです。
