### PR TITLE
fix: 推論失敗で Space が固まるのを直し、GPU デバイス消失から復帰する

### DIFF
--- a/crates/rakukan-engine/src/conv_cache.rs
+++ b/crates/rakukan-engine/src/conv_cache.rs
@@ -66,6 +66,13 @@ enum State {
         key: String,
         converter: KanaKanjiConverter,
         candidates: Vec<String>,
+        /// 推論がエラー / パニックで落ちたか。
+        ///
+        /// 候補が空になる理由は「LLM が何も出さなかった」と「推論そのものが
+        /// 失敗した」の 2 つあり、`candidates.is_empty()` だけでは区別できない。
+        /// GPU デバイス消失（ドライバ更新・スリープ復帰・TDR）は後者としてしか
+        /// 観測できないので、呼び出し元が復帰を判断するための唯一の手掛かりになる。
+        failed: bool,
     },
 }
 
@@ -143,7 +150,7 @@ fn worker_loop(cache: Arc<Cache>) {
         let converter = req.converter;
 
         let t = std::time::Instant::now();
-        let (converter, candidates) =
+        let (converter, candidates, failed) =
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 crate::digits::convert_with_digit_protection(
                     &converter,
@@ -162,15 +169,15 @@ fn worker_loop(cache: Arc<Cache>) {
                         cands.len(),
                         key
                     );
-                    (converter, cands)
+                    (converter, cands, false)
                 }
                 Ok(Err(e)) => {
                     tracing::warn!("conv-worker error: {e}");
-                    (converter, vec![])
+                    (converter, vec![], true)
                 }
                 Err(_) => {
                     tracing::error!("conv-worker PANIC");
-                    (converter, vec![])
+                    (converter, vec![], true)
                 }
             };
 
@@ -184,6 +191,7 @@ fn worker_loop(cache: Arc<Cache>) {
                 key,
                 converter,
                 candidates,
+                failed,
             };
         }
         // Done 遷移を wait_done_timeout に通知
@@ -293,6 +301,7 @@ pub fn take_ready(key: &str) -> Option<(KanaKanjiConverter, Vec<String>)> {
         key: k,
         converter,
         candidates,
+        failed,
     } = std::mem::replace(&mut inner.state, State::Idle)
     else {
         unreachable!()
@@ -323,6 +332,7 @@ pub fn take_ready(key: &str) -> Option<(KanaKanjiConverter, Vec<String>)> {
             key: k,
             converter,
             candidates,
+            failed,
         };
         return None;
     }
@@ -430,11 +440,16 @@ pub fn wait_done_timeout(timeout: std::time::Duration) -> bool {
 ///
 /// `blocking lock` を使用。`try_lock()` だとワーカーが Done を書いている瞬間に
 /// "locked" を返してしまい状態を見落とすため。
+///
+/// 推論が失敗した Done は `"done"` ではなく `"error"` を返す。呼び出し元から見た
+/// 「候補が空」は正常な結果でも起こりうるが、`"error"` は推論が落ちたときにしか
+/// 出ないため、GPU デバイス消失からの復帰判断に使える。
 pub fn status() -> &'static str {
     match CACHE.inner.lock() {
         Ok(s) => match &s.state {
             State::Idle => "idle",
             State::Running { .. } => "running",
+            State::Done { failed: true, .. } => "error",
             State::Done { .. } => "done",
         },
         Err(_) => "idle", // poisoned — フォールバック

--- a/crates/rakukan-tsf/src/engine/state.rs
+++ b/crates/rakukan-tsf/src/engine/state.rs
@@ -484,10 +484,14 @@ const BG_FAILURE_RELOAD_THRESHOLD: u32 = 3;
 
 /// 自動再起動の最短間隔。
 ///
-/// TSF DLL はアプリごとに別プロセスで動き、共有シングルトンのエンジンホストを
-/// 各プロセスが独立に監視している。間隔を置かないと、1 回のデバイス消失で
-/// 全プロセスが順番にホストを撃ち落とす reload storm になる
-/// （`engine_reload` の条件付き再起動と同じ問題）。
+/// 再起動しても直らない状態（デバイスが戻ってこない）で、打鍵のたびに
+/// ホストを撃ち直すのを防ぐ。この間に再び閾値まで失敗したら
+/// `ReloadDidNotHelp` として再起動を止め、ユーザーに次の手を伝える。
+///
+/// 状態は TSF DLL のプロセスごと（アプリごと）に持つので、アプリをまたいだ
+/// 抑止にはならない。失敗を数えるのは打鍵中のアプリだけなので、1 回の
+/// デバイス消失で全アプリが順番にホストを落とすことは起きないが、直らない
+/// 状態でアプリを切り替えて打つと、アプリごとに 1 回ずつ再起動が走る。
 const BG_FAILURE_RELOAD_COOLDOWN_SECS: u64 = 60;
 
 struct BgFailureState {
@@ -501,6 +505,10 @@ static BG_FAILURE: Mutex<BgFailureState> = Mutex::new(BgFailureState {
 });
 
 /// 推論が成功したことを記録し、連続失敗カウントを解除する。
+///
+/// 前回の自動再起動の記録も消す。成功した = その再起動は効いたので、
+/// この後の失敗は別のデバイス消失として扱い、再び再起動の対象にする
+/// （残しておくと 60 秒以内の次の失敗を `ReloadDidNotHelp` と誤判定する）。
 pub fn bg_failure_reset() {
     let Ok(mut guard) = BG_FAILURE.try_lock() else {
         return;
@@ -512,6 +520,7 @@ pub fn bg_failure_reset() {
         );
         guard.consecutive = 0;
     }
+    guard.last_reload = None;
 }
 
 /// 推論失敗を記録した結果、いま何が起きているか。

--- a/crates/rakukan-tsf/src/engine/state.rs
+++ b/crates/rakukan-tsf/src/engine/state.rs
@@ -514,47 +514,76 @@ pub fn bg_failure_reset() {
     }
 }
 
-/// 連続失敗回数と前回の自動再起動からの経過から、いま再起動すべきかを決める。
+/// 推論失敗を記録した結果、いま何が起きているか。
+///
+/// ユーザーに出す文言を決めるために使う。デバイスが消えたことも、エンジンを
+/// 入れ直せば直ることも、ユーザーには推測しようがない。黙って直すだけだと
+/// 「直らなかったとき」に打つ手が無くなるので、段階を区別して伝える。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BgFailureAction {
+    /// 閾値に達していない。単発の失敗かもしれないので様子を見る。
+    Counting,
+    /// エンジンホストの再起動を起動した。
+    Reloading,
+    /// 再起動したのにまた失敗している。エンジンの入れ直しでは直らない。
+    ReloadDidNotHelp,
+}
+
+/// 連続失敗回数と前回の自動再起動からの経過から、いま何をすべきかを決める。
 ///
 /// 時計とグローバル状態から切り離してあるのは、閾値とクールダウンの判定だけを
 /// テストできるようにするため。
-fn should_reload_after_failures(
+fn classify_failure(
     consecutive: u32,
     since_last_reload: Option<std::time::Duration>,
-) -> bool {
+) -> BgFailureAction {
     if consecutive < BG_FAILURE_RELOAD_THRESHOLD {
-        return false;
+        return BgFailureAction::Counting;
     }
     match since_last_reload {
-        Some(elapsed) => elapsed.as_secs() >= BG_FAILURE_RELOAD_COOLDOWN_SECS,
-        None => true,
+        // 直前に再起動したばかりなのに、また閾値まで失敗した
+        // = プロセスを立て直しても状況が変わっていない。
+        Some(elapsed) if elapsed.as_secs() < BG_FAILURE_RELOAD_COOLDOWN_SECS => {
+            BgFailureAction::ReloadDidNotHelp
+        }
+        _ => BgFailureAction::Reloading,
     }
 }
 
 /// 推論失敗（`bg_status() == "error"`）を記録する。
 ///
 /// 連続 `BG_FAILURE_RELOAD_THRESHOLD` 回でエンジンホストを再起動する。
-/// 再起動を起動したときだけ `true` を返す（呼び出し元のログ用）。
-pub fn bg_failure_watchdog() -> bool {
+/// 戻り値は呼び出し元がユーザーへの文言を決めるために使う。
+pub fn bg_failure_watchdog() -> BgFailureAction {
     let Ok(mut guard) = BG_FAILURE.try_lock() else {
-        return false;
+        // 他スレッドが数えている最中。二重計上を避けて様子見に倒す。
+        return BgFailureAction::Counting;
     };
     guard.consecutive += 1;
     let n = guard.consecutive;
     tracing::warn!("bg_failure_watchdog: inference failed {n} time(s) in a row");
-    if !should_reload_after_failures(n, guard.last_reload.map(|t| t.elapsed())) {
-        return false;
+    let action = classify_failure(n, guard.last_reload.map(|t| t.elapsed()));
+    match action {
+        BgFailureAction::Counting => {}
+        BgFailureAction::ReloadDidNotHelp => {
+            tracing::error!(
+                "bg_failure_watchdog: still failing after an auto engine_reload — \
+                 the GPU device is not coming back by restarting the host"
+            );
+        }
+        BgFailureAction::Reloading => {
+            tracing::warn!(
+                "bg_failure_watchdog: {n} consecutive inference failures, auto engine_reload \
+                 (GPU device likely lost — driver update / resume / TDR)"
+            );
+            guard.consecutive = 0;
+            guard.last_reload = Some(std::time::Instant::now());
+            drop(guard);
+            // デバイス復帰目的なので config が同じでも必ず再起動する
+            engine_reload_force();
+        }
     }
-    tracing::warn!(
-        "bg_failure_watchdog: {n} consecutive inference failures, auto engine_reload \
-         (GPU device likely lost — driver update / resume / TDR)"
-    );
-    guard.consecutive = 0;
-    guard.last_reload = Some(std::time::Instant::now());
-    drop(guard);
-    // デバイス復帰目的なので config が同じでも必ず再起動する
-    engine_reload_force();
-    true
+    action
 }
 
 /// 渡した `config_json` を保持し、再接続時に Create で再送する。
@@ -2516,31 +2545,37 @@ mod tests {
     #[test]
     fn bg_failure_reload_needs_consecutive_failures() {
         // 単発の失敗で再起動すると、一時的な失敗のたびに変換中のセッションを壊す。
-        assert!(!should_reload_after_failures(1, None));
-        assert!(!should_reload_after_failures(
-            BG_FAILURE_RELOAD_THRESHOLD - 1,
-            None
-        ));
-        assert!(should_reload_after_failures(
-            BG_FAILURE_RELOAD_THRESHOLD,
-            None
-        ));
+        assert_eq!(classify_failure(1, None), BgFailureAction::Counting);
+        assert_eq!(
+            classify_failure(BG_FAILURE_RELOAD_THRESHOLD - 1, None),
+            BgFailureAction::Counting
+        );
+        assert_eq!(
+            classify_failure(BG_FAILURE_RELOAD_THRESHOLD, None),
+            BgFailureAction::Reloading
+        );
+    }
+
+    #[test]
+    fn bg_failure_repeats_after_reload_are_reported_as_unrecoverable() {
+        // 再起動した直後にまた閾値まで失敗する = ホストを立て直しても直っていない。
+        // ここを Reloading と区別しないと、撃ち続けるだけでユーザーには何も伝わらない。
+        let within = std::time::Duration::from_secs(BG_FAILURE_RELOAD_COOLDOWN_SECS - 1);
+        assert_eq!(
+            classify_failure(BG_FAILURE_RELOAD_THRESHOLD, Some(within)),
+            BgFailureAction::ReloadDidNotHelp
+        );
     }
 
     #[test]
     fn bg_failure_reload_respects_cooldown() {
         // TSF DLL はアプリごとに別プロセスで動くので、クールダウンが無いと
         // 1 回のデバイス消失で全プロセスが順にホストを撃ち落とす。
-        let within = std::time::Duration::from_secs(BG_FAILURE_RELOAD_COOLDOWN_SECS - 1);
         let elapsed = std::time::Duration::from_secs(BG_FAILURE_RELOAD_COOLDOWN_SECS);
-        assert!(!should_reload_after_failures(
-            BG_FAILURE_RELOAD_THRESHOLD,
-            Some(within)
-        ));
-        assert!(should_reload_after_failures(
-            BG_FAILURE_RELOAD_THRESHOLD,
-            Some(elapsed)
-        ));
+        assert_eq!(
+            classify_failure(BG_FAILURE_RELOAD_THRESHOLD, Some(elapsed)),
+            BgFailureAction::Reloading
+        );
     }
 
     fn conv_block(reading: &str, candidate: &str, punct: Option<char>) -> ConversionBlock {

--- a/crates/rakukan-tsf/src/engine/state.rs
+++ b/crates/rakukan-tsf/src/engine/state.rs
@@ -460,6 +460,103 @@ pub fn bg_timeout_watchdog(is_stuck: bool) {
     }
 }
 
+// ─── 推論失敗のウォッチドッグ（GPU デバイス消失からの復帰） ────────────────────
+//
+// `bg_timeout_watchdog` は「詰まったまま帰ってこない」ケースしか見ていない。
+// GPU デバイスが消えると推論は詰まらず**即座に失敗して idle に戻る**ので、
+// 20 秒の停滞は永久に発生せず、そちらのウォッチドッグは一度も発火しない。
+//
+// デバイスが消える経路（いずれも IME を起動したまま起こる）:
+//   - GPU ドライバの更新（インストーラがディスプレイドライバを入れ替える）
+//   - スリープ / 休止からの復帰
+//   - TDR（ドライバのタイムアウト検出と回復）
+//
+// エンジンホストは生きていて、掴んでいる Vulkan デバイスだけが無効になるため、
+// プロセスを立て直す以外に復帰手段がない。ホストを再起動すれば新しいデバイスを
+// 作り直すので、規定回数連続で失敗したら自動で再起動する。
+
+/// 連続失敗が何回でエンジンを再起動するか。
+///
+/// 1 回で撃たないのは、単発の失敗（一時的なメモリ不足・生成タイムアウト）で
+/// 再起動して変換中のセッションを壊さないため。デバイスが消えている場合は
+/// 打鍵のたびに必ず失敗するので、2 回の猶予でも体感の遅れにはならない。
+const BG_FAILURE_RELOAD_THRESHOLD: u32 = 3;
+
+/// 自動再起動の最短間隔。
+///
+/// TSF DLL はアプリごとに別プロセスで動き、共有シングルトンのエンジンホストを
+/// 各プロセスが独立に監視している。間隔を置かないと、1 回のデバイス消失で
+/// 全プロセスが順番にホストを撃ち落とす reload storm になる
+/// （`engine_reload` の条件付き再起動と同じ問題）。
+const BG_FAILURE_RELOAD_COOLDOWN_SECS: u64 = 60;
+
+struct BgFailureState {
+    consecutive: u32,
+    last_reload: Option<std::time::Instant>,
+}
+
+static BG_FAILURE: Mutex<BgFailureState> = Mutex::new(BgFailureState {
+    consecutive: 0,
+    last_reload: None,
+});
+
+/// 推論が成功したことを記録し、連続失敗カウントを解除する。
+pub fn bg_failure_reset() {
+    let Ok(mut guard) = BG_FAILURE.try_lock() else {
+        return;
+    };
+    if guard.consecutive != 0 {
+        tracing::debug!(
+            "bg_failure_watchdog: reset after {} failures",
+            guard.consecutive
+        );
+        guard.consecutive = 0;
+    }
+}
+
+/// 連続失敗回数と前回の自動再起動からの経過から、いま再起動すべきかを決める。
+///
+/// 時計とグローバル状態から切り離してあるのは、閾値とクールダウンの判定だけを
+/// テストできるようにするため。
+fn should_reload_after_failures(
+    consecutive: u32,
+    since_last_reload: Option<std::time::Duration>,
+) -> bool {
+    if consecutive < BG_FAILURE_RELOAD_THRESHOLD {
+        return false;
+    }
+    match since_last_reload {
+        Some(elapsed) => elapsed.as_secs() >= BG_FAILURE_RELOAD_COOLDOWN_SECS,
+        None => true,
+    }
+}
+
+/// 推論失敗（`bg_status() == "error"`）を記録する。
+///
+/// 連続 `BG_FAILURE_RELOAD_THRESHOLD` 回でエンジンホストを再起動する。
+/// 再起動を起動したときだけ `true` を返す（呼び出し元のログ用）。
+pub fn bg_failure_watchdog() -> bool {
+    let Ok(mut guard) = BG_FAILURE.try_lock() else {
+        return false;
+    };
+    guard.consecutive += 1;
+    let n = guard.consecutive;
+    tracing::warn!("bg_failure_watchdog: inference failed {n} time(s) in a row");
+    if !should_reload_after_failures(n, guard.last_reload.map(|t| t.elapsed())) {
+        return false;
+    }
+    tracing::warn!(
+        "bg_failure_watchdog: {n} consecutive inference failures, auto engine_reload \
+         (GPU device likely lost — driver update / resume / TDR)"
+    );
+    guard.consecutive = 0;
+    guard.last_reload = Some(std::time::Instant::now());
+    drop(guard);
+    // デバイス復帰目的なので config が同じでも必ず再起動する
+    engine_reload_force();
+    true
+}
+
 /// 渡した `config_json` を保持し、再接続時に Create で再送する。
 ///
 /// **条件付き**: ホストが既に同じ config で動いている場合は再起動しない
@@ -2415,6 +2512,36 @@ fn is_terminal_hwnd(hwnd_val: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bg_failure_reload_needs_consecutive_failures() {
+        // 単発の失敗で再起動すると、一時的な失敗のたびに変換中のセッションを壊す。
+        assert!(!should_reload_after_failures(1, None));
+        assert!(!should_reload_after_failures(
+            BG_FAILURE_RELOAD_THRESHOLD - 1,
+            None
+        ));
+        assert!(should_reload_after_failures(
+            BG_FAILURE_RELOAD_THRESHOLD,
+            None
+        ));
+    }
+
+    #[test]
+    fn bg_failure_reload_respects_cooldown() {
+        // TSF DLL はアプリごとに別プロセスで動くので、クールダウンが無いと
+        // 1 回のデバイス消失で全プロセスが順にホストを撃ち落とす。
+        let within = std::time::Duration::from_secs(BG_FAILURE_RELOAD_COOLDOWN_SECS - 1);
+        let elapsed = std::time::Duration::from_secs(BG_FAILURE_RELOAD_COOLDOWN_SECS);
+        assert!(!should_reload_after_failures(
+            BG_FAILURE_RELOAD_THRESHOLD,
+            Some(within)
+        ));
+        assert!(should_reload_after_failures(
+            BG_FAILURE_RELOAD_THRESHOLD,
+            Some(elapsed)
+        ));
+    }
 
     fn conv_block(reading: &str, candidate: &str, punct: Option<char>) -> ConversionBlock {
         ConversionBlock {

--- a/crates/rakukan-tsf/src/tsf/candidate_window.rs
+++ b/crates/rakukan-tsf/src/tsf/candidate_window.rs
@@ -1141,6 +1141,21 @@ fn clear_llm_pending() {
     }
 }
 
+/// 推論が失敗したときに候補ウィンドウへ出す文言。
+///
+/// GPU デバイスが消えたことも、エンジンを入れ直せば直ることも、ユーザーには
+/// 推測しようがない。特に「ドライバを入れ替えた後は入れ直しが要る」は、
+/// 黙って復帰させている限り一生気付けない。自力で直せた場合はその旨を、
+/// 直せなかった場合は次に何を試せばよいかを出す。
+pub fn bg_failure_status_text(action: crate::engine::state::BgFailureAction) -> &'static str {
+    use crate::engine::state::BgFailureAction;
+    match action {
+        BgFailureAction::Counting => "⚠ 変換エンジンが応答していません（辞書候補のみ）",
+        BgFailureAction::Reloading => "⚠ 変換エンジンを再起動中…（GPU ドライバ更新後に必要）",
+        BgFailureAction::ReloadDidNotHelp => "⚠ GPU が使えません。Windows の再起動をお試しください",
+    }
+}
+
 /// 推論が失敗した（`bg_status() == "error"`）ときの後始末。
 ///
 /// 失敗した結果をキャッシュから回収して idle に戻し、連続失敗を数え、
@@ -1154,12 +1169,12 @@ fn bg_failure_fallback(site: &str) {
     {
         engine.bg_reclaim();
     }
-    crate::engine::state::bg_failure_watchdog();
+    let action = crate::engine::state::bg_failure_watchdog();
     clear_llm_pending();
     stop_waiting_timer();
 
     // 「⏳ 変換中...」のままだと、待てば直ると誤解させる。
-    // 実際には LLM 候補は来ないので、辞書候補だけであることを出す。
+    // 実際には LLM 候補は来ないので、いま何が起きているかを出す。
     let shown = match crate::engine::state::session_get() {
         Ok(sess) => {
             let cands = sess.page_candidates().to_vec();
@@ -1179,7 +1194,7 @@ fn bg_failure_fallback(site: &str) {
             &info,
             pos.left,
             pos.bottom,
-            Some("⚠ LLM 変換に失敗（辞書候補のみ）"),
+            Some(bg_failure_status_text(action)),
         );
     }
 }
@@ -1388,7 +1403,7 @@ pub fn on_waiting_timer() {
         {
             engine.bg_reclaim();
         }
-        crate::engine::state::bg_failure_watchdog();
+        let _ = crate::engine::state::bg_failure_watchdog();
         stop_waiting_timer();
         return;
     }

--- a/crates/rakukan-tsf/src/tsf/candidate_window.rs
+++ b/crates/rakukan-tsf/src/tsf/candidate_window.rs
@@ -1124,6 +1124,66 @@ pub fn stop_waiting_timer() {
     }
 }
 
+/// Selecting 中の `llm_pending` を降ろす。
+///
+/// LLM の結果を待つのをやめる全経路で必要になる。立てたまま抜けると
+/// `on_convert` が「まだ変換中」と判断して Space を無視し続けるため、
+/// 候補送りも確定もできない状態でウィンドウが固まる。
+fn clear_llm_pending() {
+    use crate::engine::state::{SessionState, session_get};
+    if let Ok(mut sess) = session_get()
+        && let SessionState::Selecting {
+            ref mut llm_pending,
+            ..
+        } = *sess
+    {
+        *llm_pending = false;
+    }
+}
+
+/// 推論が失敗した（`bg_status() == "error"`）ときの後始末。
+///
+/// 失敗した結果をキャッシュから回収して idle に戻し、連続失敗を数え、
+/// 表示中の辞書候補で操作を続けられる状態にする。GPU デバイスが消えている
+/// 場合は `bg_failure_watchdog` が規定回数でエンジンを再起動する。
+fn bg_failure_fallback(site: &str) {
+    use crate::engine::state::engine_get;
+    tracing::warn!("{site}: inference failed — falling back to dict candidates");
+    if let Ok(mut g) = engine_get()
+        && let Some(engine) = g.as_mut()
+    {
+        engine.bg_reclaim();
+    }
+    crate::engine::state::bg_failure_watchdog();
+    clear_llm_pending();
+    stop_waiting_timer();
+
+    // 「⏳ 変換中...」のままだと、待てば直ると誤解させる。
+    // 実際には LLM 候補は来ないので、辞書候補だけであることを出す。
+    let shown = match crate::engine::state::session_get() {
+        Ok(sess) => {
+            let cands = sess.page_candidates().to_vec();
+            let selected = sess.page_selected();
+            let info = sess.page_info();
+            Some((cands, selected, info))
+        }
+        Err(_) => None,
+    };
+    if let Some((cands, selected, info)) = shown
+        && !cands.is_empty()
+    {
+        let pos = crate::engine::state::caret_rect_get();
+        show_with_status(
+            &cands,
+            selected,
+            &info,
+            pos.left,
+            pos.bottom,
+            Some("⚠ LLM 変換に失敗（辞書候補のみ）"),
+        );
+    }
+}
+
 /// WM_TIMER コールバック（TSFスレッド上で呼ばれる）。
 /// bg_status == "done" になったら候補を取り出して表示する。
 pub fn on_waiting_timer() {
@@ -1157,13 +1217,21 @@ pub fn on_waiting_timer() {
     };
 
     if let Some((preedit_key, pos_x, pos_y)) = selecting_info {
-        let bg_done = match engine_get() {
-            Ok(g) => g.as_ref().map(|e| e.bg_status() == "done").unwrap_or(false),
-            Err(_) => false,
+        let bg_status = match engine_get() {
+            Ok(g) => g.as_ref().map(|e| e.bg_status()).unwrap_or("idle"),
+            Err(_) => "idle",
         };
-        if !bg_done {
+        if bg_status == "error" {
+            // 推論が落ちた。候補は永久に来ないので、待機表示のまま固まらせず
+            // 辞書候補で確定できる状態に戻す。
+            bg_failure_fallback("on_waiting_timer(selecting)");
             return;
         }
+        if bg_status != "done" {
+            return;
+        }
+        // 推論が通った = デバイスは生きている
+        crate::engine::state::bg_failure_reset();
 
         const DICT_LIMIT: usize = 40;
         let result = (|| -> Option<Vec<String>> {
@@ -1200,6 +1268,9 @@ pub fn on_waiting_timer() {
             tracing::warn!(
                 "on_waiting_timer(selecting): bg_take_candidates returned None or empty"
             );
+            // llm_pending を降ろさずに抜けると、以降 Space が候補送りに
+            // 進めなくなる（on_convert が「変換中」と見なして待ち続ける）。
+            clear_llm_pending();
             stop_waiting_timer();
             return;
         };
@@ -1301,16 +1372,32 @@ pub fn on_waiting_timer() {
     };
 
     // engine の bg_status を確認
-    let bg_done = {
+    let bg_status = {
         match engine_get() {
-            Ok(g) => g.as_ref().map(|e| e.bg_status() == "done").unwrap_or(false),
-            Err(_) => false,
+            Ok(g) => g.as_ref().map(|e| e.bg_status()).unwrap_or("idle"),
+            Err(_) => "idle",
         }
     };
 
-    if !bg_done {
+    if bg_status == "error" {
+        // 推論が落ちた。待ち続けても完了しないのでタイマーを止め、
+        // 連続失敗ならエンジンを再起動して次の変換に備える。
+        tracing::warn!("on_waiting_timer: inference failed, stopping wait");
+        if let Ok(mut g) = engine_get()
+            && let Some(engine) = g.as_mut()
+        {
+            engine.bg_reclaim();
+        }
+        crate::engine::state::bg_failure_watchdog();
+        stop_waiting_timer();
+        return;
+    }
+
+    if bg_status != "done" {
         return; // まだ実行中 → 次の WM_TIMER を待つ
     }
+    // 推論が通った = デバイスは生きている
+    crate::engine::state::bg_failure_reset();
 
     // bg=done → 候補を取り出して表示
     stop_waiting_timer();

--- a/crates/rakukan-tsf/src/tsf/candidate_window.rs
+++ b/crates/rakukan-tsf/src/tsf/candidate_window.rs
@@ -1397,14 +1397,55 @@ pub fn on_waiting_timer() {
     if bg_status == "error" {
         // 推論が落ちた。待ち続けても完了しないのでタイマーを止め、
         // 連続失敗ならエンジンを再起動して次の変換に備える。
-        tracing::warn!("on_waiting_timer: inference failed, stopping wait");
-        if let Ok(mut g) = engine_get()
-            && let Some(engine) = g.as_mut()
-        {
-            engine.bg_reclaim();
+        tracing::warn!("on_waiting_timer: inference failed — falling back to dict candidates");
+        let dict = match engine_get() {
+            Ok(mut g) => g.as_mut().map(|engine| {
+                engine.bg_reclaim();
+                engine.merge_candidates_for_reading(&wait_preedit, Vec::new(), DICT_LIMIT)
+            }),
+            Err(_) => None,
         }
-        let _ = crate::engine::state::bg_failure_watchdog();
+        .unwrap_or_default();
+        let action = crate::engine::state::bg_failure_watchdog();
         stop_waiting_timer();
+
+        // Waiting のまま抜けると「⏳ 変換中...」が残り、タイマーも止まっているので
+        // 表示を更新する経路が無くなる。辞書候補で Selecting に移し、
+        // いま何が起きているかを出す。
+        let cands = if dict.is_empty() {
+            vec![wait_preedit.clone()]
+        } else {
+            dict
+        };
+        let (page_cands, page_info_str) = {
+            let mut sess = match session_get() {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            sess.activate_selecting_with_affixes(
+                cands,
+                wait_preedit.clone(),
+                pos_x,
+                pos_y,
+                false,
+                String::new(),
+                String::new(),
+                remainder,
+                remainder_reading,
+            );
+            (
+                sess.page_candidates().to_vec(),
+                sess.page_info().to_string(),
+            )
+        };
+        show_with_status(
+            &page_cands,
+            0,
+            &page_info_str,
+            pos_x,
+            pos_y,
+            Some(bg_failure_status_text(action)),
+        );
         return;
     }
 

--- a/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
@@ -195,11 +195,15 @@ fn immediate_dict_candidates(
 /// `advance` が真なら選択を 1 つ進める。通常の Space 押下（進める）と、
 /// LLM を待つのをやめて候補表を入れ替えた直後（先頭を選んだまま見せる）の
 /// 両方から呼ぶ。呼び出し前にエンジンガードとセッションガードを手放しておくこと。
+///
+/// `status` はウィンドウ下部に出す一行。LLM を諦めた経路では、なぜ候補が
+/// 変わったのかをここで伝える（`None` なら通常表示）。
 fn show_selection(
     ctx: ITfContext,
     tid: u32,
     sink: ITfCompositionSink,
     advance: bool,
+    status: Option<&str>,
 ) -> Result<bool> {
     let mut sess = session_get()?;
     if advance {
@@ -217,12 +221,13 @@ fn show_selection(
     let remainder = sess.selecting_remainder_clone();
     drop(sess);
     candidate_window::update_selection(page_sel, &page_info);
-    candidate_window::show(
+    candidate_window::show_with_status(
         &page_cands,
         page_sel,
         &page_info,
         caret_rect_get().left,
         caret_rect_get().bottom,
+        status,
     );
     update_composition_candidate_parts(ctx, tid, sink, prefix, cand_text, remainder)?;
     Ok(true)
@@ -723,10 +728,13 @@ impl super::TextServiceFactory_Impl {
                              falling back to dict candidates",
                             bg_now
                         );
-                        if bg_now == "error" {
+                        let failure_status = if bg_now == "error" {
                             engine.bg_reclaim();
-                            crate::engine::state::bg_failure_watchdog();
-                        }
+                            let action = crate::engine::state::bg_failure_watchdog();
+                            Some(candidate_window::bg_failure_status_text(action))
+                        } else {
+                            None
+                        };
                         // LLM 待ちの間に出していたのが読みそのものだけ（候補 1 件）の
                         // 場合は、候補送りする先が無く生かなのまま詰む。辞書候補が
                         // 引けるなら差し替えて、その先頭を選んだ状態で見せる。
@@ -754,14 +762,14 @@ impl super::TextServiceFactory_Impl {
                                 *llm_pending = false;
                             }
                         }
-                        return show_selection(ctx, tid, sink, !replaced);
+                        return show_selection(ctx, tid, sink, !replaced, failure_status);
                     }
                     return Ok(true);
                 }
 
                 drop(sess);
                 drop(guard);
-                return show_selection(ctx, tid, sink, true);
+                return show_selection(ctx, tid, sink, true, None);
             }
         }
 

--- a/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
+++ b/crates/rakukan-tsf/src/tsf/factory/on_convert.rs
@@ -190,6 +190,44 @@ fn immediate_dict_candidates(
     }
 }
 
+/// Selecting 中の候補ウィンドウと composition を更新する。
+///
+/// `advance` が真なら選択を 1 つ進める。通常の Space 押下（進める）と、
+/// LLM を待つのをやめて候補表を入れ替えた直後（先頭を選んだまま見せる）の
+/// 両方から呼ぶ。呼び出し前にエンジンガードとセッションガードを手放しておくこと。
+fn show_selection(
+    ctx: ITfContext,
+    tid: u32,
+    sink: ITfCompositionSink,
+    advance: bool,
+) -> Result<bool> {
+    let mut sess = session_get()?;
+    if advance {
+        sess.next_with_page_wrap();
+    }
+    let page_cands = sess.page_candidates().to_vec();
+    let page_sel = sess.page_selected();
+    let page_info = sess.page_info();
+    let cand_text = sess
+        .current_candidate()
+        .or_else(|| sess.original_preedit())
+        .unwrap_or("")
+        .to_string();
+    let prefix = sess.selecting_prefix_clone();
+    let remainder = sess.selecting_remainder_clone();
+    drop(sess);
+    candidate_window::update_selection(page_sel, &page_info);
+    candidate_window::show(
+        &page_cands,
+        page_sel,
+        &page_info,
+        caret_rect_get().left,
+        caret_rect_get().bottom,
+    );
+    update_composition_candidate_parts(ctx, tid, sink, prefix, cand_text, remainder)?;
+    Ok(true)
+}
+
 impl super::TextServiceFactory_Impl {
     pub(super) fn on_convert(
         &self,
@@ -411,7 +449,7 @@ impl super::TextServiceFactory_Impl {
 
         // すでに選択モード中 → 1候補ずつ進む
         {
-            let mut sess = session_get()?;
+            let sess = session_get()?;
             if sess.is_selecting() {
                 // llm_pending=true の場合はLLM完了を確認して候補を更新
                 let llm_pending = matches!(
@@ -449,6 +487,10 @@ impl super::TextServiceFactory_Impl {
 
                     let bg_done = engine.bg_status() == "done";
                     tracing::debug!("on_convert[llm_pending]: after wait bg_done={}", bg_done);
+                    if bg_done {
+                        // 推論が通った = デバイスは生きている
+                        crate::engine::state::bg_failure_reset();
+                    }
                     const DICT_LIMIT: usize = 40;
 
                     if bg_done {
@@ -647,7 +689,7 @@ impl super::TextServiceFactory_Impl {
                                 }
                             }
                         }
-                    } else {
+                    } else if engine.bg_status() == "running" {
                         // まだ変換中 → 現在の候補ウィンドウをそのまま維持
                         if let Ok(sess2) = session_get() {
                             let page_cands = sess2.page_candidates().to_vec();
@@ -666,33 +708,60 @@ impl super::TextServiceFactory_Impl {
                             );
                             return Ok(true);
                         }
+                    } else {
+                        // BG 変換が走っていない（idle / error）のに llm_pending が
+                        // 立ったまま。待っても候補は永久に来ないので、ここで
+                        // llm_pending を降ろして辞書候補での候補送りに切り替える。
+                        //
+                        // これを入れないと Space が無反応のまま固まる。ウィンドウには
+                        // 「⏳ 変換中...」が出続けるので、ユーザーからは「待てば直る」
+                        // ようにしか見えず、実際には何も走っていない。
+                        // 推論が失敗して即 idle に戻る壊れ方（GPU デバイス消失）で必ず踏む。
+                        let bg_now = engine.bg_status();
+                        tracing::warn!(
+                            "on_convert[llm_pending]: bg={} with llm_pending set — giving up on LLM, \
+                             falling back to dict candidates",
+                            bg_now
+                        );
+                        if bg_now == "error" {
+                            engine.bg_reclaim();
+                            crate::engine::state::bg_failure_watchdog();
+                        }
+                        // LLM 待ちの間に出していたのが読みそのものだけ（候補 1 件）の
+                        // 場合は、候補送りする先が無く生かなのまま詰む。辞書候補が
+                        // 引けるなら差し替えて、その先頭を選んだ状態で見せる。
+                        let dict_fallback = immediate_dict_candidates(engine, &preedit, DICT_LIMIT);
+                        drop(guard);
+                        let mut replaced = false;
+                        if let Ok(mut sess2) = session_get() {
+                            let only_placeholder = matches!(
+                                *sess2,
+                                SessionState::Selecting { ref candidates, .. }
+                                    if candidates.len() <= 1
+                            );
+                            if only_placeholder && let Some(candidates) = dict_fallback {
+                                sess2.replace_selecting_candidates(
+                                    candidates,
+                                    CandidateViewSource::Dict,
+                                );
+                                replaced = true;
+                            }
+                            if let SessionState::Selecting {
+                                ref mut llm_pending,
+                                ..
+                            } = *sess2
+                            {
+                                *llm_pending = false;
+                            }
+                        }
+                        return show_selection(ctx, tid, sink, !replaced);
                     }
                     return Ok(true);
                 }
 
-                sess.next_with_page_wrap();
-                let page_cands = sess.page_candidates().to_vec();
-                let page_sel = sess.page_selected();
-                let page_info = sess.page_info();
-                let cand_text = sess
-                    .current_candidate()
-                    .or_else(|| sess.original_preedit())
-                    .unwrap_or("")
-                    .to_string();
-                let prefix = sess.selecting_prefix_clone();
-                let remainder = sess.selecting_remainder_clone();
                 drop(sess);
                 drop(guard);
-                candidate_window::update_selection(page_sel, &page_info);
-                candidate_window::show(
-                    &page_cands,
-                    page_sel,
-                    &page_info,
-                    caret_rect_get().left,
-                    caret_rect_get().bottom,
-                );
-                update_composition_candidate_parts(ctx, tid, sink, prefix, cand_text, remainder)?;
-                return Ok(true);
+                return show_selection(ctx, tid, sink, true);
             }
         }
 


### PR DESCRIPTION
## 症状

`Selecting { llm_pending: true }` のまま LLM の結果が来なくなると、**Space を押しても候補が進まなくなります**。候補ウィンドウには「⏳ 変換中...」が出続けるため、待てば直るようにしか見えませんが、実際には BG 変換は走っていません（`bg=idle`）。候補送りも確定もできず、IME を入れ直すまで戻りません。

## 再現条件

推論が「詰まる」のではなく「即座に失敗して idle に戻る」壊れ方をしたときです。実際に踏んだのは GPU ドライバの更新でした。

```
13:45:09  最後に成功した変換
13:45:25  ディスプレイドライバのインストール（nv_dispi.inf）
13:49:03  最初の conv-worker error: inference failed
          以降 124 回連続で失敗、Space は無反応のまま
```

エンジンホストは生きたままで、掴んでいる Vulkan デバイスだけが無効になります。同じ壊れ方はスリープ復帰と TDR でも起こります。

## 原因

`llm_pending` を降ろさずに抜ける経路が 2 つあります。

- `on_waiting_timer` は `bg_take_candidates` が空を返すと、そのまま `return` する
- `on_convert` は `bg_status` が `"done"` 以外を一律「まだ変換中」として扱い、実際には走っていない `idle` でも待機表示を出して `return` する

どちらも「BG 変換は必ずいつか完了する」前提です。推論が失敗して即 idle に戻ると、この前提が崩れます。

既存の `bg_timeout_watchdog` はこれを拾えません。`Running` が 20 秒続いたら再起動する作りなので、**即座に失敗して idle に戻るケースでは一度も発火しません**。

また、conv-worker は推論が `Err` やパニックで落ちても候補を空にして `Done` へ遷移するだけなので、呼び出し元からは「LLM が候補を出さなかった」正常な結果と区別できませんでした。

## 変更

**engine**: `State::Done` に `failed` を持たせ、`status()` が `"error"` を返すようにしました。RPC クライアントは元から `"error"` を受け取れる作りなので、プロトコルは変わりません。

**tsf**:

- 待つのをやめる全経路で `llm_pending` を降ろします。読みしか出ていない場合は辞書候補に差し替えるので、LLM 抜きでも候補を選べます
- `"error"` を連続 3 回で観測したらエンジンホストを再起動します。ホストが掴んだ Vulkan デバイスはプロセスを立て直す以外に復帰手段がないためです
- 単発の失敗で変換中のセッションを壊さないよう閾値を持たせ、TSF がアプリごとに別プロセスで動くことによる reload storm を避けるため 60 秒のクールダウンを置きました
- 状況を候補ウィンドウの status 行に出します

```
閾値未満         ⚠ 変換エンジンが応答していません（辞書候補のみ）
再起動を起動     ⚠ 変換エンジンを再起動中…（GPU ドライバ更新後に必要）
再起動しても駄目 ⚠ GPU が使えません。Windows の再起動をお試しください
```

3 つ目はホストを立て直しても状況が変わらない場合にしか出ません。ここを 2 つ目と区別しないと、内部で再起動を撃ち続けるだけでユーザーには「変換できない」以上の情報が届きません。**ドライバを入れ替えた後にエンジンの入れ直しが要ることは、黙って復帰させている限りユーザーには気付けない**、というのがこの PR で一番直したかった点です。

## 検証

- `cargo fmt --all -- --check`
- `cargo clippy -p rakukan-tsf --release -- -D warnings`
- `cargo clippy -p rakukan-engine --release -- -D warnings`
- `cargo test -p rakukan-tsf --release` … 102 passed（閾値・クールダウン・復帰不能の判定に 3 本追加）

実機で GPU デバイスを意図的に消す検証はできていません。上記のログは実際に踏んだときのものです。
