### PR TITLE
fix(engine): ひらがなモードで打った英単語が後ろの日本語ごと壊れるのを直す（#26 の出し直し）

### DIFF
--- a/crates/rakukan-engine/src/conv_cache.rs
+++ b/crates/rakukan-engine/src/conv_cache.rs
@@ -42,7 +42,10 @@ use crate::{DigitCandidateKind, default_digit_candidates_order};
 
 /// ワーカーへの変換リクエスト（single-slot 上書き式キュー）
 struct Request {
+    /// TSF 側の打鍵そのままの読みと照合するキャッシュキー。
     hiragana: String,
+    /// 先頭ラテン語ランの復元後、変換器へ実際に渡す読み。
+    conv_reading: String,
     committed: String,
     converter: KanaKanjiConverter,
     n: usize,
@@ -142,6 +145,7 @@ fn worker_loop(cache: Arc<Cache>) {
         };
 
         let key = req.hiragana.clone();
+        let conv_reading = req.conv_reading.clone();
         let committed = req.committed.clone();
         let n = req.n;
         let digit_candidates_order = req.digit_candidates_order.clone();
@@ -154,7 +158,7 @@ fn worker_loop(cache: Arc<Cache>) {
             match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 crate::digits::convert_with_digit_protection(
                     &converter,
-                    &key,
+                    &conv_reading,
                     &committed,
                     n,
                     &digit_candidates_order,
@@ -209,8 +213,11 @@ fn worker_loop(cache: Arc<Cache>) {
 /// # 戻り値
 /// - `None`       = ワーカーに渡した（converter の所有権はキャッシュへ）
 /// - `Some(conv)` = 渡せなかった（同一キー実行中 or lock 取得失敗）
+// 引数を構造体にまとめても Request と二重になるだけなので、この形を保つ。
+#[allow(clippy::too_many_arguments)]
 pub fn start(
     hiragana: String,
+    conv_reading: String,
     committed: String,
     converter: KanaKanjiConverter,
     n: usize,
@@ -242,6 +249,7 @@ pub fn start(
 
     inner.pending = Some(Request {
         hiragana,
+        conv_reading,
         committed,
         converter,
         n,

--- a/crates/rakukan-engine/src/latin_run.rs
+++ b/crates/rakukan-engine/src/latin_run.rs
@@ -1,0 +1,215 @@
+//! 先頭ラテン語ランの復元
+//!
+//! ひらがなモードのまま英単語を打つと、読みはローマ字が部分的にかなへ潰れた姿に
+//! なる。`seedream` なら `せえdれあm`（トライで解決できなかった子音だけが素の
+//! ASCII として残る）。この読みをそのまま [`crate::digits`] のリテラル保護レイヤーへ
+//! 渡すと、素の `d` / `m` だけがアルファベット run とみなされ、`せえ` / `れあ` /
+//! 後続の日本語が別々に LLM へ渡る。結果は `せえdレアmのぺーす` のような読めない
+//! 文字列になる。
+//!
+//! ここでは打鍵ログ（[`crate::InputEntry`]）と読みを突き合わせ、**読みの先頭にある
+//! ラテン語ランを打鍵どおりのラテン文字へ戻した読み**を作る。
+//! `せえdれあmのぺーすはどう` → `seedreamのぺーすはどう`。これを変換器へ渡せば、
+//! 既存のリテラル保護レイヤーが `Alpha("seedream")` ＋ `Kana("のぺーすはどう")` に
+//! 分割し、LLM は日本語部分だけを見る（→ `seedreamのペースはどう`）。
+//!
+//! # 境界をログから読む
+//! 各エントリは「打鍵（`typed`）」と「そのとき `hiragana_buf` に足した文字列
+//! （`output`）」を持ち、未確定ローマ字（`pending_romaji_buf`）はログに入らない。
+//! したがって `output` を累積した位置が、そのままローマ字とかなの対応表になる。
+//! 変換器に流し直して対応を作り直す必要はない。
+//!
+//! # 扱える形が限られる理由
+//! 素の ASCII は「ローマ字がかなに潰れきらなかった位置」を示すだけで、英単語の
+//! 左右の端そのものは指さない。かなは全てローマ字由来なので、境界の手掛かりは
+//! 打鍵ログにも存在しない。誤った位置で切ると日本語側を壊すため、両端が決まる形
+//! だけを扱う:
+//!
+//! - 右端は「素の ASCII の直後が助詞」の場合に限る。`seedream` は末尾が `m` で
+//!   止まるので `のぺーすはどう` との境目が読める。`google`（読み `ごおgぇ`）は
+//!   素の ASCII が途中の `g` で終わるため右端が決まらず、対象外
+//! - 左端は「読みの先頭」に限る。しかも先頭であること自体は証明できないので、
+//!   ラテン語ランの範囲に助詞のかなが現れたら日本語の前置きを疑って手を引く
+//!   （`これはseedreamの…` の `これは` を巻き込まないため）
+//!
+//! # 全体がラテン文字の場合は対象外
+//! 後続にかなが無い読みは、この関数の目的である「英単語と日本語の境目を読める
+//! ようにする」対象ではないので `None` を返す。
+
+/// 英単語の直後に来る助詞。読みの右端を決める唯一の手掛かりであり、
+/// 左端に日本語の前置きが無いことを疑うための手掛かりでもある。
+const PARTICLES: [char; 10] = ['の', 'を', 'は', 'が', 'に', 'で', 'と', 'も', 'や', 'へ'];
+
+fn is_boundary_particle(c: char) -> bool {
+    PARTICLES.contains(&c)
+}
+
+/// 読みの先頭ラテン語ランを打鍵どおりのラテン文字へ戻した読みを返す。
+///
+/// `log` は [`crate::RakunEngine`] の `input_log`、`detached_at` は
+/// `log_detached_at`、`hiragana` は `hiragana_buf` を渡す。復元できない場合は
+/// `None`（呼び出し側は読みをそのまま使う）。
+pub(crate) fn normalize_leading_latin(
+    log: &[crate::InputEntry],
+    detached_at: usize,
+    hiragana: &str,
+) -> Option<String> {
+    // F9/F10 の force_preedit 後はログと読みが対応しない。
+    if hiragana.is_empty() || log.is_empty() || detached_at != 0 {
+        return None;
+    }
+    // Backspace 再生などでログと読みがずれていたら手を出さない。
+    let logged: String = log.iter().map(|entry| entry.output.as_str()).collect();
+    if logged != hiragana {
+        return None;
+    }
+
+    let chars: Vec<char> = hiragana.chars().collect();
+    // 読みに素の ASCII 英字が残っている＝ローマ字がかなに変換しきれていない。
+    // 普通の日本語の読みはここで弾かれる。
+    let split = chars.iter().rposition(|c| c.is_ascii_alphabetic())? + 1;
+    if split >= chars.len() {
+        // 後続のかなが無い＝読み全体が英単語。分ける境目が無いので何もしない。
+        return None;
+    }
+    // 素の ASCII の直後が助詞のときだけ「ここで英単語が終わった」と判断する。
+    // 助詞以外が続くなら、英単語がまだ続いているのか日本語が始まったのかを読みから
+    // 区別できない（`ごおgぇ` = google / `せえdれあmつかう` = 英単語＋助詞なしの続き）。
+    if !is_boundary_particle(chars[split]) {
+        return None;
+    }
+    // ラテン語ランの範囲に助詞が混ざっていたら、そこまでが日本語の前置きである
+    // 可能性を否定できないので復元しない。`これはせえdれあmのぺーす` は最後の素
+    // ASCII が `m`・直後が `の` なので上の判定は通ってしまうが、ここで `は` を見て
+    // 手を引く。前置きを巻き込むと `korehaseedream` がリテラル化され、日本語側が
+    // 丸ごと壊れる。英単語のローマ字が助詞と同じかなを生む語（`monitor` →
+    // `もにとr`）も復元されなくなるが、その場合は復元しないだけで害が無い。
+    if chars[..split].iter().copied().any(is_boundary_particle) {
+        return None;
+    }
+
+    // `output` の累積がちょうど `split` になるエントリ境界を探す。境界がエントリの
+    // 内側にある（跨いでしまう）場合は復元できない。
+    let mut output_len = 0;
+    let end = log.iter().position(|entry| {
+        output_len += entry.output.chars().count();
+        output_len == split
+    })? + 1;
+    // 記号・数字・Shift+英字が混ざる範囲は digits.rs のリテラル保護レイヤーの担当。
+    if log[..end]
+        .iter()
+        .any(|entry| entry.kind != crate::InputKind::Romaji)
+    {
+        return None;
+    }
+    let mut head: String = log[..end]
+        .iter()
+        .map(|entry| entry.typed.as_str())
+        .collect();
+    if !head.chars().all(|c| c.is_ascii_alphanumeric())
+        || !head.chars().any(|c| c.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    head.extend(chars[split..].iter());
+    Some(head)
+}
+
+#[cfg(test)]
+mod tests {
+    fn engine_after(typed: &str) -> crate::RakunEngine {
+        let mut e = crate::RakunEngine::new(crate::EngineConfig::default());
+        for c in typed.chars() {
+            e.push_char(c);
+        }
+        e
+    }
+
+    fn conv_reading_after(typed: &str) -> String {
+        engine_after(typed).conv_reading()
+    }
+
+    /// 各ケースの読みが想定どおりかを先に固定する。ここがずれていると、下の
+    /// テストが「復元する / しない」の理由を取り違える。
+    /// `seedream` 単体の末尾 `m` は次の打鍵まで未確定バッファに残るので読みに出ない。
+    #[test]
+    fn readings_match_expected() {
+        let cases = [
+            ("seedreamnope-suhadou", "せえdれあmのぺーすはどう"),
+            ("seedreamnope-", "せえdれあmのぺー"),
+            ("kanntannna", "かんたんな"),
+            ("seedream", "せえdれあ"),
+            ("google", "ごおgぇ"),
+            ("seedreamtsukau", "せえdれあmつかう"),
+            (
+                "korehaseedreamnope-suhadou",
+                "これはせえdれあmのぺーすはどう",
+            ),
+        ];
+        for (typed, reading) in cases {
+            assert_eq!(
+                engine_after(typed).hiragana_text(),
+                reading,
+                "typed={typed}"
+            );
+        }
+    }
+
+    #[test]
+    fn restores_leading_latin_word_before_kana() {
+        // 「seedreamのぺーすはどう」と打った状態
+        assert_eq!(
+            conv_reading_after("seedreamnope-suhadou"),
+            "seedreamのぺーすはどう"
+        );
+    }
+
+    #[test]
+    fn restores_leading_latin_word_mid_typing() {
+        // 変換が追いつく前（`のぺー` まで打った時点）でも同じ位置で切れる
+        assert_eq!(conv_reading_after("seedreamnope-"), "seedreamのぺー");
+    }
+
+    #[test]
+    fn ignores_pure_kana_reading() {
+        assert_eq!(conv_reading_after("kanntannna"), "かんたんな");
+    }
+
+    #[test]
+    fn ignores_reading_that_is_entirely_latin() {
+        // 読み全体が英単語 → 分ける境目が無いので対象外
+        assert_eq!(conv_reading_after("seedream"), "せえdれあ");
+    }
+
+    #[test]
+    fn ignores_latin_word_whose_right_edge_is_unknown() {
+        // google は末尾の `ぇ` まで英単語だが、素の ASCII は途中の `g` が最後。
+        // ここで切ると `googlれ` に化けるので切らない。
+        assert_eq!(conv_reading_after("google"), "ごおgぇ");
+    }
+
+    #[test]
+    fn ignores_latin_word_not_followed_by_a_particle() {
+        // 助詞以外が続くと、英単語が終わったのか続いているのか読みから決まらない
+        assert_eq!(conv_reading_after("seedreamtsukau"), "せえdれあmつかう");
+    }
+
+    #[test]
+    fn ignores_latin_run_after_japanese_prefix() {
+        // 前置き `これは` は日本語だが、読みの上では英単語の一部と区別できない。
+        // 巻き込んで `korehaseedream` をリテラル化すると日本語側が壊れる。
+        assert_eq!(
+            conv_reading_after("korehaseedreamnope-suhadou"),
+            "これはせえdれあmのぺーすはどう"
+        );
+    }
+
+    #[test]
+    fn ignores_reading_out_of_sync_with_log() {
+        // F9/F10 の force_preedit 後はログと読みが対応しない
+        let mut e = engine_after("seedreamno");
+        e.force_preedit("SEEDREAMの".to_string());
+        assert_ne!(e.log_detached_at, 0);
+        assert_eq!(e.conv_reading(), "SEEDREAMの");
+    }
+}

--- a/crates/rakukan-engine/src/lib.rs
+++ b/crates/rakukan-engine/src/lib.rs
@@ -19,6 +19,7 @@
 // ── 統合した karukan-engine モジュール ────────────────────────────────────────
 pub mod kana;
 pub mod kanji;
+mod latin_run;
 pub mod romaji;
 
 pub use kana::{
@@ -913,6 +914,32 @@ impl RakunEngine {
         true
     }
 
+    /// 変換器へ渡す読み。
+    ///
+    /// ひらがなモードのまま打った先頭の英単語は、読みの上ではローマ字が潰れた姿
+    /// （`せえdれあm`）になっている。これをそのままリテラル保護レイヤーへ渡すと
+    /// 素の `d` / `m` だけがアルファベット run になり、日本語がぶつ切りで LLM に
+    /// 渡って壊れる。打鍵ログから英単語を復元して `seedreamのぺーすはどう` の形に
+    /// してから変換へ回す。
+    ///
+    /// 復元できない読み（普通の日本語 / 読み全体が英単語 / 日本語の前置きがある /
+    /// F9-F10 で force_preedit した後）はそのまま返す。
+    pub fn conv_reading(&self) -> String {
+        if let Some(normalized) = latin_run::normalize_leading_latin(
+            &self.input_log,
+            self.log_detached_at,
+            &self.hiragana_buf,
+        ) {
+            info!(
+                "engine::conv_reading: latin run restored {:?} -> {:?}",
+                self.hiragana_buf, normalized
+            );
+            normalized
+        } else {
+            self.hiragana_buf.clone()
+        }
+    }
+
     pub fn convert(&self, num_candidates: usize) -> Result<Vec<String>, EngineError> {
         if self.hiragana_buf.is_empty() {
             return Ok(vec![]);
@@ -923,7 +950,7 @@ impl RakunEngine {
             .ok_or(EngineError::ModelNotInitialized)?;
         digits::convert_with_digit_protection(
             kanji,
-            &self.hiragana_buf,
+            &self.conv_reading(),
             &self.committed,
             num_candidates,
             &self.config.digit_candidates_order,
@@ -1176,6 +1203,7 @@ impl RakunEngine {
         }
 
         let hiragana = self.hiragana_buf.clone();
+        let conv_reading = self.conv_reading();
         let committed = self.committed.clone();
         if hiragana.is_empty() {
             return false;
@@ -1187,6 +1215,7 @@ impl RakunEngine {
         if let Some(conv) = self.kanji.take() {
             match conv_cache::start(
                 hiragana,
+                conv_reading,
                 committed,
                 conv,
                 n_cands,


### PR DESCRIPTION
#38 の実装です。#26 を現行 main（Step 10 マージ後）へ出し直しました。#26 はクローズして構いません。

## 症状

ひらがなモードのまま英単語を打つと、読みはローマ字が部分的にかなへ潰れた姿になります（`seedream` → `せえdれあm`）。この読みをそのまま `digits.rs` のリテラル保護レイヤーへ渡すと、素の ASCII として残った子音（`d` / `m`）だけがアルファベット run と判定され、`せえ` / `れあ` / 後続の日本語が別々に LLM へ渡ります。結果、`seedreamのペースはどう` が `seedreamnoぺーすはどう` になります（#38 の問題点 1・2）。

## 直し方

打鍵ログと読みを突き合わせ、読みの先頭にあるラテン語ランを打鍵どおりのラテン文字へ戻した読みを作り、変換器にはそちらを渡します。

```
読み        せえdれあmのぺーすはどう
変換へ渡す  seedreamのぺーすはどう
リテラル保護  Alpha("seedream") + Kana("のぺーすはどう")
```

キャッシュのキー（`conv_cache::Request::hiragana`）は打鍵そのままの読みのままにして、変換器へ渡す読み（`conv_reading`）だけを分けています。呼び出し側が結果を引くときに使うのは打鍵そのままの読みだからです。

## Step 10 で変わった分

#26 では `romaji_input_log` を `RomajiConverter` へ流し直して「ローマ字 n 文字 ↔ かな m 文字」の境界表を作っていましたが、`input_log` は各エントリが `typed` と `output` を持ち、未確定ローマ字はログに入らないので、`output` の累積位置がそのまま境界になります。流し直しは削りました。「境界は未確定バッファを引いた位置で取る」という #38 の観察は、ログの側で最初から満たされている形です。

## 復元する範囲

素の ASCII は「ローマ字がかなに潰れきらなかった位置」を示すだけで、英単語の左右の端そのものは指しません。誤った位置で切ると日本語側を壊すので、両端が決まる形だけを扱います。

- **右端**は素の ASCII の直後が助詞（`の` `を` `は` `が` `に` `で` `と` `も` `や` `へ`）のときに限ります。`google`（読み `ごおgぇ`）は末尾の `ぇ` まで英単語なのに最後の素 ASCII は途中の `g` なので、対象外です
- **左端**は読みの先頭に限ります。さらに、ラテン語ランの範囲に助詞のかなが現れたら復元しません

左端の条件は #26 から変えた点です。#26 は「読みの先頭から最後の素 ASCII まで」を無条件にラテン語ランと見ていたため、`これはseedreamのぺーすはどう`（読み `これはせえdれあmのぺーすはどう`）で `korehaseedream` を返し、日本語の前置き `これは` を壊していました（#26 への Codex レビュー P1）。前置きが日本語なのか英単語の一部なのかは読みからもログからも決まらない（#38 の問題点 4）ので、疑わしい場合は手を引く側に倒しています。

副作用として、英単語のローマ字が助詞と同じかなを生む語（`monitor` → `もにとr`）も復元されなくなります。この場合は復元しないだけで、日本語を壊す方向の誤りは起きません。

## 復元しないケース

| 打鍵 | 読み | 変換へ渡す読み | 理由 |
|---|---|---|---|
| `seedreamnope-suhadou` | `せえdれあmのぺーすはどう` | `seedreamのぺーすはどう` | 復元する |
| `seedreamnope-` | `せえdれあmのぺー` | `seedreamのぺー` | 変換が追いつく前でも同じ位置で切れる |
| `kanntannna` | `かんたんな` | そのまま | 素の ASCII が無い |
| `seedream` | `せえdれあ` | そのまま | 後続のかなが無く境目が無い |
| `google` | `ごおgぇ` | そのまま | 右端が決まらない |
| `seedreamtsukau` | `せえdれあmつかう` | そのまま | 助詞が続かない |
| `korehaseedreamnope-suhadou` | `これはせえdれあmのぺーすはどう` | そのまま | 日本語の前置きを疑う |

F9/F10 の `force_preedit` 後（`log_detached_at != 0`）と、ログの `output` 連結が `hiragana_buf` と一致しない場合も復元しません。

## 変更範囲

- 追加: `crates/rakukan-engine/src/latin_run.rs`
- 変更: `crates/rakukan-engine/src/lib.rs`（`conv_reading()` の追加、`convert()` と `bg_start()` の呼び出し）
- 変更: `crates/rakukan-engine/src/conv_cache.rs`（`Request` にフィールド 1 個、`start()` に引数 1 個）

TSF 側の変更はありません。`romaji_input_log` の表現や Backspace 再生には触っていません。

## 検証

- `cargo fmt --all -- --check`
- `cargo clippy -p rakukan-engine --release --all-targets -- -D warnings`
- `cargo test -p rakukan-engine --release --lib`（240 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
